### PR TITLE
Exile Leveling updates

### DIFF
--- a/modules/leveling tracker.ahk
+++ b/modules/leveling tracker.ahk
@@ -97,7 +97,7 @@ If (A_GuiControl = "leveling_guide_import") ;import-button in the settings menu
 	FileRead, json_areas, data\leveling tracker\areas.json
 	FileRead, json_gems, data\leveling tracker\gems.json
 	FileRead, json_quests, data\leveling tracker\quests.json
-	json_import := (SubStr(clipboard, 1, 2) = "[[") ? clipboard : ""
+	json_import := (SubStr(clipboard, 1, 2) = "[{") ? clipboard : ""
 	If (json_import = "")
 	{
 		LLK_ToolTip("invalid import data")
@@ -117,9 +117,9 @@ If (A_GuiControl = "leveling_guide_import") ;import-button in the settings menu
 	Loop, % parsed.Length() ;parse all acts
 	{
 		loop := A_Index
-		Loop, % parsed[loop].Length() ;parse steps in individual acts
+		Loop, % parsed[loop].steps.Length() ;parse steps in individual acts
 		{
-			step := parsed[loop][A_Index]
+			step := parsed[loop].steps[A_Index]
 			step_text := ""
 			If (step.type = "fragment_step")
 			{
@@ -161,10 +161,12 @@ If (A_GuiControl = "leveling_guide_import") ;import-button in the settings menu
 								step_text .= quests[questID].name
 							Case "quest_text":
 								step_text .= !InStr(step_text, "kill") ? value : "" ;omit quest-items related to killing bosses
-							Case "get_waypoint":
-								step_text .= "waypoint"
 							Case "waypoint":
-								step_text .= (areaID != "") ? "waypoint-travel to areaID" areaID : InStr(step_text, "for the broken") ? "waypoint" : "the waypoint"
+								step_text .= InStr(step_text, "for the broken") ? "waypoint" : "the waypoint"
+							Case "waypoint_use":
+								step_text .= "waypoint-travel to areaID" areaID
+							Case "waypoint_get":
+								step_text .= "waypoint"
 							Case "logout":
 								step_text .= "relog, enter areaID" areaID
 							Case "portal":
@@ -185,9 +187,9 @@ If (A_GuiControl = "leveling_guide_import") ;import-button in the settings menu
 								step_text .= value
 							Case "ascend":
 								step_text .= "enter and complete the " version " lab"
-							Case "vendor_reward":
+							Case "reward_vendor":
 								step_text .= "buy item: " step.parts[A_Index].item
-							Case "quest_reward":
+							Case "reward_quest":
 								step_text .= "take reward: " step.parts[A_Index].item
 						}
 					}

--- a/modules/leveling tracker.ahk
+++ b/modules/leveling tracker.ahk
@@ -140,7 +140,7 @@ If (A_GuiControl = "leveling_guide_import") ;import-button in the settings menu
 						type := parts[A_Index].type
 						value := parts[A_Index].value
 						areaID := parts[A_Index].areaId
-						target_areaID := parts[A_Index].targetAreaId
+						dstAreaID := parts[A_Index].dstAreaId
 						questID := parts[A_Index].questId
 						version := parts[A_Index].version
 						direction := StrReplace(parts[A_Index].dirIndex, 0, "north,")
@@ -164,15 +164,15 @@ If (A_GuiControl = "leveling_guide_import") ;import-button in the settings menu
 							Case "waypoint":
 								step_text .= InStr(step_text, "for the broken") ? "waypoint" : "the waypoint"
 							Case "waypoint_use":
-								step_text .= "waypoint-travel to areaID" areaID
+								step_text .= "waypoint-travel to areaID" dstAreaID
 							Case "waypoint_get":
 								step_text .= "waypoint"
 							Case "logout":
 								step_text .= "relog, enter areaID" areaID
 							Case "portal":
-								If (target_areaID = "")
+								If (dstAreaID = "")
 									step_text .= "portal"
-								Else step_text .= "portal to areaID" target_areaID
+								Else step_text .= "portal to areaID" dstAreaID
 							Case "trial":
 								step_text .= "the lab-trial"
 							Case "arena":


### PR DESCRIPTION
Export format has updated to cater for custom act/section naming, now exports
```typescript
type Step = FragmentStep | GemStep;
interface Section {
  name: string;
  steps: Step[];
}
type Route = Section[];
```
instead of
```typescript
type Step = FragmentStep | GemStep;
type Route = Step[][];
```
Some steps have been updated for more consistent naming