### PR TITLE
v1.52.4 (Hotfix 1) merge

### DIFF
--- a/data/changelog.json
+++ b/data/changelog.json
@@ -1,6 +1,8 @@
 [
   [
 	["1.52.4", 15204],
+	"hotfix 1: regex fix for sacrifice and sacred wisps (leveltracker)",
+	"hotfix 1: add missing necropolis league color, and support for portal scroll hotkey (maptracker)",
 	"necropolis (3.24) updates: betrayal-info, horizon-tooltips, item-info",
 	"GENERAL REMINDER: SCREEN-CHECKS MAY NEED RECALIBRATION AFTER MAJOR GAME PATCHES. IF THE OMNI-KEY DOESN'T WORK ANYMORE, TEST THE CHECKS AND RECALIBRATE IF NECESSARY",
 	"leveling tracker: changed effective exp panel, improved gem-regex",

--- a/data/english/UI.txt
+++ b/data/english/UI.txt
@@ -651,6 +651,7 @@
 		m_maptracker_dialogue		=	"–> dialogue tracking:"				;## tracking is done via in-game dialogue in the chat-box
 		m_maptracker_screen		=	"–> screen tracking:"				;## tracking is done via screen-reading
 		m_maptracker_portal		=	"reminder when using portal scrolls"		;## shows a reminder-tooltip when activating a portal scroll
+		m_maptracker_portal		=	"portal scroll hotkey:"
 
 
 

--- a/data/english/help tooltips.json
+++ b/data/english/help tooltips.json
@@ -354,7 +354,11 @@
     ],
     "maptracker portal reminder": [
       "when using a portal scroll, a tooltip will remind you to double-check if map content has been completed",
-      "requires the <inventory> pixel-check to be set up correctly in the <screen-checks> section of the menu"
+      "requires you to specify the correct in-game hotkey below"
+    ],
+    "maptracker portal hotkey": [
+      "type in the in-game hotkey for <use portal scroll>",
+      "check the links above if it uses special keys/combinations"
     ],
     "maptracker loot-tracker": [
       "items you ctrl-click into the stash will be logged",

--- a/data/global/[leveltracker] gem regex.json
+++ b/data/global/[leveltracker] gem regex.json
@@ -1316,7 +1316,7 @@
     "1"
   ],
   "Sacrifice Support": [
-    "sac.*rt",
+    "sacri.*rt",
     "3"
   ],
   "Sadism Support": [

--- a/data/versions.json
+++ b/data/versions.json
@@ -1,3 +1,4 @@
 {
-  "_release": [15204, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"]
+  "_release": [15204, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"],
+  "hotfix": 1
 }

--- a/modules/hotkeys.ahk
+++ b/modules/hotkeys.ahk
@@ -239,6 +239,7 @@ HotkeysTab()
 
 #If settings.maptracker.kills && settings.features.maptracker && (vars.maptracker.refresh_kills = 1) ;pre-defined context for hotkey command
 #If WinExist("ahk_id "vars.hwnd.horizons.main) ;pre-defined context for hotkey command
+#If (vars.log.areaID = vars.maptracker.map.id) && settings.features.maptracker && settings.maptracker.mechanics && settings.maptracker.portal_reminder && vars.maptracker.map.content.Count() && WinActive("ahk_id " vars.hwnd.poe_client) ;pre-defined context for hotkey command
 
 #If vars.general.wMouse && (vars.general.wMouse = vars.hwnd.ClientFiller) ;prevent clicking and activating the filler GUI
 *MButton::
@@ -263,10 +264,6 @@ HotkeysTab()
 ~Shift UP::
 WinSet, TransColor, % "Purple " (InStr(A_ThisHotkey, "UP") ? "255" : 0), % "ahk_id " vars.hwnd.ocr_tooltip.main
 Return
-
-#If (vars.log.areaID = vars.maptracker.map.id) && settings.features.maptracker && settings.maptracker.mechanics && settings.maptracker.portal_reminder && vars.pixelsearch.inventory.check && vars.maptracker.map.content.Count() && (vars.general.xMouse > vars.monitor.x + vars.client.xc)
-
-~RButton UP::MaptrackerReminder()
 
 #If !vars.mapinfo.toggle && (vars.system.timeout = 0) && (vars.general.wMouse = vars.hwnd.poe_client) && WinExist("ahk_id "vars.hwnd.mapinfo.main) ;clicking the client to hide the map-info tooltip
 

--- a/modules/map tracker.ahk
+++ b/modules/map tracker.ahk
@@ -19,7 +19,7 @@
 	settings.maptracker.sidecontent := LLK_IniRead("ini\map tracker.ini", "Settings", "track side-areas", 0)
 	settings.maptracker.mechanics := LLK_IniRead("ini\map tracker.ini", "Settings", "track league mechanics", 0)
 	settings.maptracker.portal_reminder := LLK_IniRead("ini\map tracker.ini", "Settings", "portal-scroll reminder", 0)
-	settings.maptracker.portal_hotkey := LLK_IniRead("ini\map tracker.ini", "Settings", "portal-scroll hotkey", "b")
+	settings.maptracker.portal_hotkey := LLK_IniRead("ini\map tracker.ini", "Settings", "portal-scroll hotkey")
 	If !Blank(settings.maptracker.portal_hotkey)
 	{
 		Hotkey, If, (vars.log.areaID = vars.maptracker.map.id) && settings.features.maptracker && settings.maptracker.mechanics && settings.maptracker.portal_reminder && vars.maptracker.map.content.Count() && WinActive("ahk_id " vars.hwnd.poe_client)

--- a/modules/omni-key.ahk
+++ b/modules/omni-key.ahk
@@ -217,7 +217,7 @@ OmniContext(mode := 0)
 		Return "gemnotepad"
 	If settings.features.leveltracker && vars.hwnd.tooltipgem_notes && WinExist("ahk_id " vars.hwnd.tooltipgem_notes) && (item.rarity = LangTrans("items_gem"))
 		Return "gemnotes"
-	While settings.features.leveltracker && GetKeyState(ThisHotkey_copy, "P") && (item.rarity = LangTrans("items_gem"))
+	While settings.features.leveltracker && vars.hwnd.leveltracker.main && GetKeyState(ThisHotkey_copy, "P") && (item.rarity = LangTrans("items_gem"))
 		If (A_TickCount >= vars.omnikey.start + 200)
 			Return "gemnotes"
 	If (item.name = "Orb of Horizons")

--- a/modules/settings menu.ahk
+++ b/modules/settings menu.ahk
@@ -1728,7 +1728,17 @@ Settings_maptracker()
 		}
 		Gui, %GUI%: Font, cWhite
 		Gui, %GUI%: Add, Checkbox, % "xs Section gSettings_maptracker2 HWNDhwnd Checked"settings.maptracker.portal_reminder, % LangTrans("m_maptracker_portal")
+		ControlGetPos,,, wControl,,, ahk_id %hwnd%
 		vars.hwnd.settings.portal_reminder := vars.hwnd.help_tooltips["settings_maptracker portal reminder"] := hwnd, handle := ""
+		If settings.maptracker.portal_reminder
+		{
+			Gui, %GUI%: Add, Text, % "xs Section HWNDhwnd0", % LangTrans("m_maptracker_portal", 2)
+			ControlGetPos,,, wControl2,,, ahk_id %hwnd0%
+			Gui, %GUI%: Font, % "s" settings.general.fSize - 4
+			Gui, %GUI%: Add, Edit, % "ys cBlack gSettings_maptracker2 HWNDhwnd w" wControl - wControl2 - settings.general.fWidth, % settings.maptracker.portal_hotkey
+			Gui, %GUI%: Font, % "s" settings.general.fSize
+			vars.hwnd.settings.portal_hotkey := vars.hwnd.help_tooltips["settings_maptracker portal hotkey"] := hwnd
+		}
 	}
 
 	Gui, %GUI%: Font, bold underline
@@ -1808,6 +1818,20 @@ Settings_maptracker2(cHWND)
 		Case "portal_reminder":
 			settings.maptracker.portal_reminder := LLK_ControlGet(cHWND)
 			IniWrite, % settings.maptracker.portal_reminder, ini\map tracker.ini, settings, portal-scroll reminder
+			Settings_menu("mapping tracker")
+		Case "portal_hotkey":
+			input := LLK_ControlGet(cHWND)
+			If (StrLen(input) != 1)
+				Loop, Parse, % "#!^+"
+					input := StrReplace(input, A_LoopField)
+			If !Blank(input) && GetKeyVK(input)
+			{
+				settings.maptracker.portal_hotkey := LLK_ControlGet(cHWND)
+				IniWrite, % settings.maptracker.portal_hotkey, ini\map tracker.ini, settings, portal-scroll hotkey
+				GuiControl, +cBlack, % cHWND
+				Init_maptracker()
+			}
+			Else GuiControl, +cRed, % cHWND
 		Default:
 			If InStr(check, "font_")
 			{
@@ -2593,7 +2617,7 @@ Settings_ScreenChecksValid()
 	valid := 1
 	For key, val in vars.pixelsearch.list
 	{
-		If (key = "inventory" && !(settings.iteminfo.compare || settings.maptracker.mechanics && settings.maptracker.portal_reminder || settings.iteminfo.trigger || settings.mapinfo.trigger))
+		If (key = "inventory" && !(settings.iteminfo.compare || settings.iteminfo.trigger || settings.mapinfo.trigger))
 			continue
 		valid *= vars.pixelsearch[key].color1 ? 1 : 0
 	}


### PR DESCRIPTION
- leveltracker: regex fix for sacrifice and sacred wisps
- maptracker: added missing necropolis league color
- maptracker: added support for new portal scroll hotkey, moved league-content reminder from portal-scroll right-click to hotkey