### PR TITLE
v1.52.4 (Hotfix 2) merge

### DIFF
--- a/data/changelog.json
+++ b/data/changelog.json
@@ -3,6 +3,8 @@
 	["1.52.4", 15204],
 	"hotfix 1: regex fix for sacrifice and sacred wisps (leveltracker)",
 	"hotfix 1: add missing necropolis league color, and support for portal scroll hotkey (maptracker)",
+	"hotfix 2: add support for reworded/new map mods (map-info)",
+	"hotfix 2: add support for new eldritch altars (tldr-tooltips)",
 	"necropolis (3.24) updates: betrayal-info, horizon-tooltips, item-info",
 	"GENERAL REMINDER: SCREEN-CHECKS MAY NEED RECALIBRATION AFTER MAJOR GAME PATCHES. IF THE OMNI-KEY DOESN'T WORK ANYMORE, TEST THE CHECKS AND RECALIBRATE IF NECESSARY",
 	"leveling tracker: changed effective exp panel, improved gem-regex",

--- a/data/english/eldritch altars.json
+++ b/data/english/eldritch altars.json
@@ -1,1 +1,840 @@
-{"boss":[["to maximum cold resistance\r\nto cold resistance\r\nto maximum lightning resistance\r\nto lightning resistance","(max) cold & lightning res"],["additional physical damage reduction","additional pdr"],["prevent of suppressed spell damage\r\nchance to suppress spell damage","spell suppression"],["gain of physical damage as extra damage of a random element\r\ndamage penetrates of enemy elemental resistances","phys as extra ele dmg | ele pen"],["gain of physical damage as extra cold damage\r\ncover enemies in frost on hit","phys as extra cold dmg | cover in frost"],["global chance to blind enemies on hit\r\nincreased blind effect","blind on hit | inc blind effect"],["gain of maximum life as extra maximum energy shield","max life as extra max energy shield"],["gain of physical damage as extra cold damage\r\nall damage with hits can chill","phys as extra cold dmg | all dmg with hits can chill"],["hits always shock\r\ngain of physical damage as extra lightning damage\r\nall damage can shock","phys as extra lightning damage | hits always shock"],["create consecrated ground on hit, lasting seconds","consecrated ground on hit"],["to maximum fire resistance\r\nto fire resistance\r\nto maximum chaos resistance\r\nto chaos resistance","(max) fire & chaos res"],["to armour","+50k armour"],["gain of physical damage as extra fire damage\r\ncover enemies in ash on hit","phys as extra fire dmg | cover in ash"],["enemies lose flask charges every seconds and cannot gain flask charges for seconds after being hit","on hit: enemies lose & cannot gain flask charges"],["hits always ignite\r\ngain of physical damage as extra fire damage\r\nall damage can ignite","phys as extra fire dmg | hits always ignite"],["gain of physical damage as extra chaos damage\r\npoison on hit\r\nall damage from hits can poison","phys as extra chaos dmg | poison on hit"],["increased armour\r\nincreased evasion rating","inc armour & evasion"],["nearby enemies are hindered, with reduced movement speed","nearby enemies are hindered"],["final boss drops additional divine orbs","divine orbs"],["final boss drops additional exalted orbs","exalted orbs"],["final boss drops additional regal orbs","regal orbs"],["final boss drops additional lesser eldritch ichors","t1 eldritch ichors"],["final boss drops additional greater eldritch ichors","t2 eldritch ichors"],["final boss drops additional grand eldritch ichors","t3 eldritch ichors"],["final boss drops additional veiled chaos orbs","veiled chaos orbs"],["final boss drops additional orbs of alteration","orbs of alteration"],["final boss drops additional blessed orbs","blessed orbs"],["final boss drops additional orbs of scouring","orbs of scouring"],["final boss drops additional chromatic orbs","chromatic orbs"],["final boss drops additional orbs of fusing","orbs of fusing"],["final boss drops additional jeweller's orbs","jeweller's orbs"],["final boss drops additional rusted breach scarabs","rusted breach scarabs"],["final boss drops additional polished breach scarabs","polished breach scarabs"],["final boss drops additional gilded breach scarabs","gilded breach scarabs"],["final boss drops additional rusted elder scarabs","rusted elder scarabs"],["final boss drops additional polished elder scarabs","polished elder scarabs"],["final boss drops additional gilded elder scarabs","gilded elder scarabs"],["final boss drops additional rusted sulphite scarabs","rusted sulphite scarabs"],["final boss drops additional polished sulphite scarabs","polished sulphite scarabs"],["final boss drops additional gilded sulphite scarabs","gilded sulphite scarabs"],["final boss drops additional rusted ambush scarabs","rusted ambush scarabs"],["final boss drops additional polished ambush scarabs","polished ambush scarabs"],["final boss drops additional gilded ambush scarabs","gilded ambush scarabs"],["final boss drops additional rusted harbinger scarabs","rusted harbinger scarabs"],["final boss drops additional polished harbinger scarabs","polished harbinger scarabs"],["final boss drops additional gilded harbinger scarabs","gilded harbinger scarabs"],["final boss drops additional rusted expedition scarabs","rusted expedition scarabs"],["final boss drops additional polished expedition scarabs","polished expedition scarabs"],["final boss drops additional gilded expedition scarabs","gilded expedition scarabs"],["final boss drops additional rusted legion scarabs","rusted legion scarabs"],["final boss drops additional polished legion scarabs","polished legion scarabs"],["final boss drops additional gilded legion scarabs","gilded legion scarabs"],["final boss drops additional rusted abyss scarabs","rusted abyss scarabs"],["final boss drops additional polished abyss scarabs","polished abyss scarabs"],["final boss drops additional gilded abyss scarabs","gilded abyss scarabs"],["final boss drops additional divination cards which reward basic currency","div cards: basic currency"],["final boss drops additional divination cards which reward league currency","div cards: league currency"],["final boss drops additional divination cards which reward other divination cards","div cards: other div cards"],["final boss drops additional divination cards which reward gems","div cards: gems"],["final boss drops additional divination cards which reward levelled gems","div cards: levelled gems"],["final boss drops additional divination cards which reward quality gems","div cards: quality gems"],["final boss drops additional awakened sextants","awakened sextants"],["final boss drops additional orbs of binding","orbs of binding"],["final boss drops additional orbs of horizons","orbs of horizons"],["final boss drops additional orbs of unmaking","orbs of unmaking"],["final boss drops additional cartographer's chisels","cartographer's chisels"],["final boss drops additional lesser eldritch embers","t1 eldritch embers"],["final boss drops additional greater eldritch embers","t2 eldritch embers"],["final boss drops additional grand eldritch embers","t3 eldritch embers"],["final boss drops additional orbs of annulment","orbs of annulment"],["final boss drops additional vaal orbs","vaal orbs"],["final boss drops additional enkindling orbs","enkindling orbs"],["final boss drops additional instilling orbs","instilling orbs"],["final boss drops additional orbs of regret","orbs of regret"],["final boss drops additional glassblower's baubles","glassblower's baubles"],["final boss drops additional gemcutter's prisms","gemcutter's prisms"],["final boss drops additional chaos orbs","chaos orbs"],["final boss drops additional rusted bestiary scarabs","rusted bestiary scarabs"],["final boss drops additional polished bestiary scarabs","polished bestiary scarabs"],["final boss drops additional gilded bestiary scarabs","gilded bestiary scarabs"],["final boss drops additional rusted torment scarabs","rusted torment scarabs"],["final boss drops additional polished torment scarabs","polished torment scarabs"],["final boss drops additional gilded torment scarabs","gilded torment scarabs"],["final boss drops additional rusted ultimatum scarabs","rusted ultimatum scarabs"],["final boss drops additional polished ultimatum scarabs","polished ultimatum scarabs"],["final boss drops additional gilded ultimatum scarabs","gilded ultimatum scarabs"],["final boss drops additional rusted blight scarabs","rusted blight scarabs"],["final boss drops additional polished blight scarabs","polished blight scarabs"],["final boss drops additional gilded blight scarabs","gilded blight scarabs"],["final boss drops additional rusted reliquary scarabs","rusted reliquary scarabs"],["final boss drops additional polished reliquary scarabs","polished reliquary scarabs"],["final boss drops additional gilded reliquary scarabs","gilded reliquary scarabs"],["final boss drops additional rusted divination scarabs","rusted divination scarabs"],["final boss drops additional polished divination scarabs","polished divination scarabs"],["final boss drops additional gilded divination scarabs","gilded divination scarabs"],["final boss drops additional rusted shaper scarabs","rusted shaper scarabs"],["final boss drops additional polished shaper scarabs","polished shaper scarabs"],["final boss drops additional gilded shaper scarabs","gilded shaper scarabs"],["final boss drops additional rusted cartography scarabs","rusted cartography scarabs"],["final boss drops additional polished cartography scarabs","polished cartography scarabs"],["final boss drops additional gilded cartography scarabs","gilded cartography scarabs"],["final boss drops additional divination cards which reward a unique weapon","div cards: unique weapon"],["final boss drops additional divination cards which reward a unique armour","div cards: unique armour"],["final boss drops additional divination cards which reward unique jewellery","div cards: unique jewellery"],["final boss drops additional divination cards which reward a corrupted unique item","div cards: corrupted unique item"],["final boss drops additional divination cards which reward a map","div cards: map"],["final boss drops additional divination cards which reward a unique map","div cards: unique map"],["final boss drops additional divination cards which reward a corrupted item","div cards: corrupted item"],["final boss drops additional lesser eldritch ichor","t1 eldritch ichor"],["final boss drops additional greater eldritch ichor","t2 eldritch ichor"],["final boss drops additional grand eldritch ichor","t3 eldritch ichor"],["final boss drops additional lesser eldritch ember","t1 eldritch ember"],["final boss drops additional greater eldritch ember","t2 eldritch ember"],["final boss drops additional grand eldritch ember","t3 eldritch ember"]],"minions":[["overwhelm physical damage reduction","overwhelm pdr"],["skills fire additional projectiles","+projectiles"],["increased attack speed\r\nincreased cast speed\r\nincreased movement speed","inc m/a/c speed"],["to maximum cold resistance\r\nto cold resistance\r\nto maximum lightning resistance\r\nto lightning resistance","(max) cold & lightning res"],["additional physical damage reduction","additional pdr"],["prevent of suppressed spell damage\r\nchance to suppress spell damage","spell suppression"],["chance to remove a random charge from enemy on hit","remove random charge on hit"],["drops chilled ground on death, lasting seconds","drops chilled ground on death"],["chance to create shocked ground on death, lasting seconds","shocked ground on death"],["inflict grasping vine on hit","inflict grasping vine on hit"],["gain of physical damage as extra lightning damage","phys as extra lightning dmg"],["gain of physical damage as extra cold damage","phys as extra cold dmg"],["drops burning ground on death, lasting seconds","burning ground on death"],["create consecrated ground on death, lasting seconds","consecrated ground on death"],["gain of physical damage as extra damage of a random element\r\ninflict fire, cold, and lightning exposure on hit","phys as extra ele dmg | tri-exposure on hit"],["enemies lose flask charges every seconds and cannot gain flask charges for seconds after being hit","on hit: enemies lose & cannot gain flask charges"],["to maximum fire resistance\r\nto fire resistance\r\nto maximum chaos resistance\r\nto chaos resistance","(max) fire & chaos res"],["to armour","+50k armour"],["increased area of effect","inc area of effect"],["increased evasion rating","inc evasion"],["gain of physical damage as extra chaos damage","phys as extra chaos dmg"],["gain of physical damage as extra fire damage","phys as extra fire dmg"],["chance to drop an additional divine orb","divine orb"],["chance to drop an additional exalted orb","exalted orb"],["chance to drop an additional regal orb","regal orb"],["chance to drop an additional lesser eldritch ichor","t1 eldritch ichor"],["chance to drop an additional greater eldritch ichor","t2 eldritch ichor"],["chance to drop an additional grand eldritch ichor","t3 eldritch ichor"],["chance to drop an additional veiled chaos orb","veiled chaos orb"],["chance to drop an additional orb of alteration","orb of alteration"],["chance to drop an additional blessed orb","blessed orb"],["chance to drop an additional orb of scouring","orb of scouring"],["chance to drop an additional chromatic orb","chromatic orb"],["chance to drop an additional orb of fusing","orb of fusing"],["chance to drop an additional jeweller's orb","jeweller's orb"],["chance to drop an additional rusted breach scarab","rusted breach scarab"],["chance to drop an additional polished breach scarab","polished breach scarab"],["chance to drop an additional gilded breach scarab","gilded breach scarab"],["chance to drop an additional rusted elder scarab","rusted elder scarab"],["chance to drop an additional polished elder scarab","polished elder scarab"],["chance to drop an additional gilded elder scarab","gilded elder scarab"],["chance to drop an additional rusted sulphite scarab","rusted sulphite scarab"],["chance to drop an additional polished sulphite scarab","polished sulphite scarab"],["chance to drop an additional gilded sulphite scarab","gilded sulphite scarab"],["chance to drop an additional rusted ambush scarab","rusted ambush scarab"],["chance to drop an additional polished ambush scarab","polished ambush scarab"],["chance to drop an additional gilded ambush scarab","gilded ambush scarab"],["chance to drop an additional rusted harbinger scarab","rusted harbinger scarab"],["chance to drop an additional polished harbinger scarab","polished harbinger scarab"],["chance to drop an additional gilded harbinger scarab","gilded harbinger scarab"],["chance to drop an additional rusted expedition scarab","rusted expedition scarab"],["chance to drop an additional polished expedition scarab","polished expedition scarab"],["chance to drop an additional gilded expedition scarab","gilded expedition scarab"],["chance to drop an additional rusted legion scarab","rusted legion scarab"],["chance to drop an additional polished legion scarab","polished legion scarab"],["chance to drop an additional gilded legion scarab","gilded legion scarab"],["chance to drop an additional rusted abyss scarab","rusted abyss scarab"],["chance to drop an additional polished abyss scarab","polished abyss scarab"],["chance to drop an additional gilded abyss scarab","gilded abyss scarab"],["chance to drop an additional divination card which rewards basic currency","div card: basic currency"],["chance to drop an additional divination card which rewards league currency","div card: league currency"],["chance to drop an additional divination card which rewards other divination cards","div card: other div cards"],["chance to drop an additional divination card which rewards gems","div card: gems"],["chance to drop an additional divination card which rewards levelled gems","div card: levelled gems"],["chance to drop an additional divination card which rewards quality gems","div card: quality gems"],["chance to drop an additional awakened sextant","awakened sextant"],["chance to drop an additional orb of binding","orb of binding"],["chance to drop an additional orb of horizons","orb of horizons"],["chance to drop an additional orb of unmaking","orb of unmaking"],["chance to drop an additional cartographer's chisel","cartographer's chisel"],["chance to drop an additional lesser eldritch ember","t1 eldritch ember"],["chance to drop an additional greater eldritch ember","t2 eldritch ember"],["chance to drop an additional grand eldritch ember","t3 eldritch ember"],["chance to drop an additional orb of annulment","orb of annulment"],["chance to drop an additional vaal orb","vaal orb"],["chance to drop an additional enkindling orb","enkindling orb"],["chance to drop an additional instilling orb","instilling orb"],["chance to drop an additional orb of regret","orb of regret"],["chance to drop an additional glassblower's bauble","glassblower's bauble"],["chance to drop an additional gemcutter's prism","gemcutter's prism"],["chance to drop an additional chaos orb","chaos orb"],["chance to drop an additional rusted bestiary scarab","rusted bestiary scarab"],["chance to drop an additional polished bestiary scarab","polished bestiary scarab"],["chance to drop an additional gilded bestiary scarab","gilded bestiary scarab"],["chance to drop an additional rusted torment scarab","rusted torment scarab"],["chance to drop an additional polished torment scarab","polished torment scarab"],["chance to drop an additional gilded torment scarab","gilded torment scarab"],["chance to drop an additional rusted ultimatum scarab","rusted ultimatum scarab"],["chance to drop an additional polished ultimatum scarab","polished ultimatum scarab"],["chance to drop an additional gilded ultimatum scarab","gilded ultimatum scarab"],["chance to drop an additional rusted blight scarab","rusted blight scarab"],["chance to drop an additional polished blight scarab","polished blight scarab"],["chance to drop an additional gilded blight scarab","gilded blight scarab"],["chance to drop an additional rusted reliquary scarab","rusted reliquary scarab"],["chance to drop an additional polished reliquary scarab","polished reliquary scarab"],["chance to drop an additional gilded reliquary scarab","gilded reliquary scarab"],["chance to drop an additional rusted divination scarab","rusted divination scarab"],["chance to drop an additional polished divination scarab","polished divination scarab"],["chance to drop an additional gilded divination scarab","gilded divination scarab"],["chance to drop an additional rusted shaper scarab","rusted shaper scarab"],["chance to drop an additional polished shaper scarab","polished shaper scarab"],["chance to drop an additional gilded shaper scarab","gilded shaper scarab"],["chance to drop an additional rusted cartography scarab","rusted cartography scarab"],["chance to drop an additional polished cartography scarab","polished cartography scarab"],["chance to drop an additional gilded cartography scarab","gilded cartography scarab"],["chance to drop an additional divination card which rewards a unique weapon","div card: unique weapon"],["chance to drop an additional divination card which rewards a unique armour","div card: unique armour"],["chance to drop an additional divination card which rewards unique jewellery","div card: unique jewellery"],["chance to drop an additional divination card which rewards a corrupted unique item","div card: corrupted unique item"],["chance to drop an additional divination card which rewards a map","div card: map"],["chance to drop an additional divination card which rewards a unique map","div card: unique map"],["chance to drop an additional divination card which rewards a corrupted item","div card: corrupted item"]],"player":[["- to cold resistance\r\n- to lightning resistance","\u2013cold & \u2013lightning res"],["- additional physical damage reduction","\u2013additional pdr"],["reduced defences per frenzy charge","\u2013defences per f-charge"],["reduced recovery rate of life, mana and energy shield per endurance charge","\u2013life/mana/es recovery per e-charge"],["- to critical strike multiplier per power charge","\u2013crit multi per p-charge"],["chance for enemies to drop chilled ground when hitting you, no more than once every seconds","chance: chilled ground when hit"],["chance for enemies to drop shocked ground when hitting you, no more than once every seconds","chance: shocked ground when hit"],["all damage taken from hits can sap you\r\nchance to be sapped when hit","chance to be sapped when hit"],["nearby enemies gain of their physical damage as extra cold damage","nearby enemies: phys as extra cold dmg"],["nearby enemies gain of their physical damage as extra lightning damage","nearby enemies: phys as extra lightning dmg"],["projectiles are fired in random directions","random projectiles"],["non-damaging ailments you inflict are reflected back to you","non-dmg ailments are reflected"],["- to fire resistance\r\n- to chaos resistance","\u2013fire & \u2013chaos res"],["- to armour\r\n- to evasion rating","\u2013armour/evasion"],["increased flask charges used\r\nreduced flask effect duration","flasks: +cost/\u2013duration"],["take chaos damage per second during any flask effect","chaos dot during any flask effect"],["all damage taken from hits can scorch you\r\nchance to be scorched when hit","chance to be scorched when hit"],["curses you inflict are reflected back to you","curses are reflected"],["chance for enemies to drop burning ground when hitting you, no more than once every seconds","chance: burning ground when hit"],["chance to be targeted by a meteor when you use a flask","chance: meteor on flask"],["nearby enemies gain of their physical damage as extra fire damage","nearby enemies: phys as extra fire dmg"],["nearby enemies gain of their physical damage as extra chaos damage","nearby enemies: phys as extra chaos dmg"],["basic currency items dropped by slain enemies have chance to be duplicated","dupe chance: basic currency"],["unique items dropped by slain enemies have chance to be duplicated","dupe chance: unique"],["scarabs dropped by slain enemies have chance to be duplicated","dupe chance: scarabs"],["maps dropped by slain enemies have chance to be duplicated","dupe chance: maps"],["divination cards dropped by slain enemies have chance to be duplicated","dupe chance: div cards"],["increased quantity of items found in this area\r\nincreased rarity of items found in this area","inc quantity & rarity"],["gems dropped by slain enemies have chance to be duplicated","dupe chance: gems"],["increased quantity of items found in this area","inc quantity"],["increased rarity of items found in this area","inc rarity"],["increased experience gain","inc experience gain"]]}
+{
+  "boss": [
+    [
+      "to maximum cold resistance\r\nto cold resistance\r\nto maximum lightning resistance\r\nto lightning resistance",
+      "(max) cold & lightning res"
+    ],
+    [
+      "additional physical damage reduction",
+      "additional pdr"
+    ],
+    [
+      "prevent of suppressed spell damage\r\nchance to suppress spell damage",
+      "spell suppression"
+    ],
+    [
+      "gain of physical damage as extra damage of a random element\r\ndamage penetrates of enemy elemental resistances",
+      "phys as extra ele dmg | ele pen"
+    ],
+    [
+      "gain of physical damage as extra cold damage\r\ncover enemies in frost on hit",
+      "phys as extra cold dmg | cover in frost"
+    ],
+    [
+      "global chance to blind enemies on hit\r\nincreased blind effect",
+      "blind on hit | inc blind effect"
+    ],
+    [
+      "gain of maximum life as extra maximum energy shield",
+      "max life as extra max energy shield"
+    ],
+    [
+      "gain of physical damage as extra cold damage\r\nall damage with hits can chill",
+      "phys as extra cold dmg | all dmg with hits can chill"
+    ],
+    [
+      "hits always shock\r\ngain of physical damage as extra lightning damage\r\nall damage can shock",
+      "phys as extra lightning damage | hits always shock"
+    ],
+    [
+      "create consecrated ground on hit, lasting seconds",
+      "consecrated ground on hit"
+    ],
+    [
+      "to maximum fire resistance\r\nto fire resistance\r\nto maximum chaos resistance\r\nto chaos resistance",
+      "(max) fire & chaos res"
+    ],
+    [
+      "to armour",
+      "+50k armour"
+    ],
+    [
+      "gain of physical damage as extra fire damage\r\ncover enemies in ash on hit",
+      "phys as extra fire dmg | cover in ash"
+    ],
+    [
+      "enemies lose flask charges every seconds and cannot gain flask charges for seconds after being hit",
+      "on hit: enemies lose & cannot gain flask charges"
+    ],
+    [
+      "hits always ignite\r\ngain of physical damage as extra fire damage\r\nall damage can ignite",
+      "phys as extra fire dmg | hits always ignite"
+    ],
+    [
+      "gain of physical damage as extra chaos damage\r\npoison on hit\r\nall damage from hits can poison",
+      "phys as extra chaos dmg | poison on hit"
+    ],
+    [
+      "increased armour\r\nincreased evasion rating",
+      "inc armour & evasion"
+    ],
+    [
+      "nearby enemies are hindered, with reduced movement speed",
+      "nearby enemies are hindered"
+    ],
+    [
+      "final boss drops additional divine orbs",
+      "divine orbs"
+    ],
+    [
+      "final boss drops additional exalted orbs",
+      "exalted orbs"
+    ],
+    [
+      "final boss drops additional regal orbs",
+      "regal orbs"
+    ],
+    [
+      "final boss drops additional lesser eldritch ichors",
+      "t1 eldritch ichors"
+    ],
+    [
+      "final boss drops additional greater eldritch ichors",
+      "t2 eldritch ichors"
+    ],
+    [
+      "final boss drops additional grand eldritch ichors",
+      "t3 eldritch ichors"
+    ],
+    [
+      "final boss drops additional orbs of alteration",
+      "orbs of alteration"
+    ],
+    [
+      "final boss drops additional blessed orbs",
+      "blessed orbs"
+    ],
+    [
+      "final boss drops additional orbs of scouring",
+      "orbs of scouring"
+    ],
+    [
+      "final boss drops additional chromatic orbs",
+      "chromatic orbs"
+    ],
+    [
+      "final boss drops additional orbs of fusing",
+      "orbs of fusing"
+    ],
+    [
+      "final boss drops additional jeweller's orbs",
+      "jeweller's orbs"
+    ],
+    [
+      "final boss drops additional divination cards which reward basic currency",
+      "div cards: basic currency"
+    ],
+    [
+      "final boss drops additional divination cards which reward league currency",
+      "div cards: league currency"
+    ],
+    [
+      "final boss drops additional divination cards which reward other divination cards",
+      "div cards: other div cards"
+    ],
+    [
+      "final boss drops additional divination cards which reward gems",
+      "div cards: gems"
+    ],
+    [
+      "final boss drops additional divination cards which reward levelled gems",
+      "div cards: levelled gems"
+    ],
+    [
+      "final boss drops additional divination cards which reward quality gems",
+      "div cards: quality gems"
+    ],
+    [
+      "final boss drops additional orbs of binding",
+      "orbs of binding"
+    ],
+    [
+      "final boss drops additional orbs of horizons",
+      "orbs of horizons"
+    ],
+    [
+      "final boss drops additional orbs of unmaking",
+      "orbs of unmaking"
+    ],
+    [
+      "final boss drops additional cartographer's chisels",
+      "cartographer's chisels"
+    ],
+    [
+      "final boss drops additional lesser eldritch embers",
+      "t1 eldritch embers"
+    ],
+    [
+      "final boss drops additional greater eldritch embers",
+      "t2 eldritch embers"
+    ],
+    [
+      "final boss drops additional grand eldritch embers",
+      "t3 eldritch embers"
+    ],
+    [
+      "final boss drops additional orbs of annulment",
+      "orbs of annulment"
+    ],
+    [
+      "final boss drops additional vaal orbs",
+      "vaal orbs"
+    ],
+    [
+      "final boss drops additional enkindling orbs",
+      "enkindling orbs"
+    ],
+    [
+      "final boss drops additional instilling orbs",
+      "instilling orbs"
+    ],
+    [
+      "final boss drops additional orbs of regret",
+      "orbs of regret"
+    ],
+    [
+      "final boss drops additional glassblower's baubles",
+      "glassblower's baubles"
+    ],
+    [
+      "final boss drops additional gemcutter's prisms",
+      "gemcutter's prisms"
+    ],
+    [
+      "final boss drops additional chaos orbs",
+      "chaos orbs"
+    ],
+    [
+      "final boss drops additional divination cards which reward a unique weapon",
+      "div cards: unique weapon"
+    ],
+    [
+      "final boss drops additional divination cards which reward a unique armour",
+      "div cards: unique armour"
+    ],
+    [
+      "final boss drops additional divination cards which reward unique jewellery",
+      "div cards: unique jewellery"
+    ],
+    [
+      "final boss drops additional divination cards which reward a corrupted unique item",
+      "div cards: corrupted unique item"
+    ],
+    [
+      "final boss drops additional divination cards which reward a map",
+      "div cards: map"
+    ],
+    [
+      "final boss drops additional divination cards which reward a unique map",
+      "div cards: unique map"
+    ],
+    [
+      "final boss drops additional divination cards which reward a corrupted item",
+      "div cards: corrupted item"
+    ],
+    [
+      "final boss drops additional lesser eldritch ichor",
+      "t1 eldritch ichor"
+    ],
+    [
+      "final boss drops additional greater eldritch ichor",
+      "t2 eldritch ichor"
+    ],
+    [
+      "final boss drops additional grand eldritch ichor",
+      "t3 eldritch ichor"
+    ],
+    [
+      "final boss drops additional lesser eldritch ember",
+      "t1 eldritch ember"
+    ],
+    [
+      "final boss drops additional greater eldritch ember",
+      "t2 eldritch ember"
+    ],
+    [
+      "final boss drops additional grand eldritch ember",
+      "t3 eldritch ember"
+    ],
+    [
+      "final boss drops additional breach scarabs",
+      "breach scarabs"
+    ],
+    [
+      "final boss drops additional delirium scarabs",
+      "delirium scarabs"
+    ],
+    [
+      "final boss drops additional legion scarabs",
+      "legion scarabs"
+    ],
+    [
+      "final boss drops additional blight scarabs",
+      "blight scarabs"
+    ],
+    [
+      "final boss drops additional ritual scarabs",
+      "ritual scarabs"
+    ],
+    [
+      "final boss drops additional harvest scarabs",
+      "harvest scarabs"
+    ],
+    [
+      "final boss drops additional ultimatum scarabs",
+      "ultimatum scarabs"
+    ],
+    [
+      "final boss drops additional abyss scarabs",
+      "abyss scarabs"
+    ],
+    [
+      "final boss drops additional expedition scarabs",
+      "expedition scarabs"
+    ],
+    [
+      "final boss drops additional betrayal scarabs",
+      "betrayal scarabs"
+    ],
+    [
+      "final boss drops additional bestiary scarabs",
+      "bestiary scarabs"
+    ],
+    [
+      "final boss drops additional incursion scarabs",
+      "incursion scarabs"
+    ],
+    [
+      "final boss drops additional sulphite scarabs",
+      "sulphite scarabs"
+    ],
+    [
+      "final boss drops additional influence scarabs",
+      "influence scarabs"
+    ],
+    [
+      "final boss drops additional cartography scarabs",
+      "cartography scarabs"
+    ],
+    [
+      "final boss drops additional divination scarabs",
+      "divination scarabs"
+    ],
+    [
+      "final boss drops additional anarchy scarabs",
+      "anarchy scarabs"
+    ],
+    [
+      "final boss drops additional harbinger scarabs",
+      "harbinger scarabs"
+    ],
+    [
+      "final boss drops additional miscellaneous scarabs",
+      "miscellaneous scarabs"
+    ],
+    [
+      "final boss drops additional beyond scarabs",
+      "beyond scarabs"
+    ],
+    [
+      "final boss drops additional torment scarabs",
+      "torment scarabs"
+    ],
+    [
+      "final boss drops additional ambush scarabs",
+      "ambush scarabs"
+    ],
+    [
+      "final boss drops additional domination scarabs",
+      "domination scarabs"
+    ],
+    [
+      "final boss drops additional essence scarabs",
+      "essence scarabs"
+    ],
+    [
+      "final boss drops additional reliquary scarabs",
+      "reliquary scarabs"
+    ]
+  ],
+  "minions": [
+    [
+      "overwhelm physical damage reduction",
+      "overwhelm pdr"
+    ],
+    [
+      "skills fire additional projectiles",
+      "+projectiles"
+    ],
+    [
+      "increased attack speed\r\nincreased cast speed\r\nincreased movement speed",
+      "inc m/a/c speed"
+    ],
+    [
+      "to maximum cold resistance\r\nto cold resistance\r\nto maximum lightning resistance\r\nto lightning resistance",
+      "(max) cold & lightning res"
+    ],
+    [
+      "additional physical damage reduction",
+      "additional pdr"
+    ],
+    [
+      "prevent of suppressed spell damage\r\nchance to suppress spell damage",
+      "spell suppression"
+    ],
+    [
+      "chance to remove a random charge from enemy on hit",
+      "remove random charge on hit"
+    ],
+    [
+      "drops chilled ground on death, lasting seconds",
+      "chilled ground on death"
+    ],
+    [
+      "chance to create shocked ground on death, lasting seconds",
+      "shocked ground on death"
+    ],
+    [
+      "inflict grasping vine on hit",
+      "grasping vine on hit"
+    ],
+    [
+      "gain of physical damage as extra lightning damage",
+      "phys as extra lightning dmg"
+    ],
+    [
+      "gain of physical damage as extra cold damage",
+      "phys as extra cold dmg"
+    ],
+    [
+      "drops burning ground on death, lasting seconds",
+      "burning ground on death"
+    ],
+    [
+      "create consecrated ground on death, lasting seconds",
+      "consecrated ground on death"
+    ],
+    [
+      "gain of physical damage as extra damage of a random element\r\ninflict fire, cold, and lightning exposure on hit",
+      "phys as extra ele dmg | tri-exposure on hit"
+    ],
+    [
+      "enemies lose flask charges every seconds and cannot gain flask charges for seconds after being hit",
+      "on hit: enemies lose & cannot gain flask charges"
+    ],
+    [
+      "to maximum fire resistance\r\nto fire resistance\r\nto maximum chaos resistance\r\nto chaos resistance",
+      "(max) fire & chaos res"
+    ],
+    [
+      "to armour",
+      "+50k armour"
+    ],
+    [
+      "increased area of effect",
+      "inc area of effect"
+    ],
+    [
+      "increased evasion rating",
+      "inc evasion"
+    ],
+    [
+      "gain of physical damage as extra chaos damage",
+      "phys as extra chaos dmg"
+    ],
+    [
+      "gain of physical damage as extra fire damage",
+      "phys as extra fire dmg"
+    ],
+    [
+      "chance to drop an additional divine orb",
+      "divine orb"
+    ],
+    [
+      "chance to drop an additional exalted orb",
+      "exalted orb"
+    ],
+    [
+      "chance to drop an additional regal orb",
+      "regal orb"
+    ],
+    [
+      "chance to drop an additional lesser eldritch ichor",
+      "t1 eldritch ichor"
+    ],
+    [
+      "chance to drop an additional greater eldritch ichor",
+      "t2 eldritch ichor"
+    ],
+    [
+      "chance to drop an additional grand eldritch ichor",
+      "t3 eldritch ichor"
+    ],
+    [
+      "chance to drop an additional orb of alteration",
+      "orb of alteration"
+    ],
+    [
+      "chance to drop an additional blessed orb",
+      "blessed orb"
+    ],
+    [
+      "chance to drop an additional orb of scouring",
+      "orb of scouring"
+    ],
+    [
+      "chance to drop an additional chromatic orb",
+      "chromatic orb"
+    ],
+    [
+      "chance to drop an additional orb of fusing",
+      "orb of fusing"
+    ],
+    [
+      "chance to drop an additional jeweller's orb",
+      "jeweller's orb"
+    ],
+    [
+      "chance to drop an additional divination card which rewards basic currency",
+      "div card: basic currency"
+    ],
+    [
+      "chance to drop an additional divination card which rewards league currency",
+      "div card: league currency"
+    ],
+    [
+      "chance to drop an additional divination card which rewards other divination cards",
+      "div card: other div cards"
+    ],
+    [
+      "chance to drop an additional divination card which rewards gems",
+      "div card: gems"
+    ],
+    [
+      "chance to drop an additional divination card which rewards levelled gems",
+      "div card: levelled gems"
+    ],
+    [
+      "chance to drop an additional divination card which rewards quality gems",
+      "div card: quality gems"
+    ],
+    [
+      "chance to drop an additional orb of binding",
+      "orb of binding"
+    ],
+    [
+      "chance to drop an additional orb of horizons",
+      "orb of horizons"
+    ],
+    [
+      "chance to drop an additional orb of unmaking",
+      "orb of unmaking"
+    ],
+    [
+      "chance to drop an additional cartographer's chisel",
+      "cartographer's chisel"
+    ],
+    [
+      "chance to drop an additional lesser eldritch ember",
+      "t1 eldritch ember"
+    ],
+    [
+      "chance to drop an additional greater eldritch ember",
+      "t2 eldritch ember"
+    ],
+    [
+      "chance to drop an additional grand eldritch ember",
+      "t3 eldritch ember"
+    ],
+    [
+      "chance to drop an additional orb of annulment",
+      "orb of annulment"
+    ],
+    [
+      "chance to drop an additional vaal orb",
+      "vaal orb"
+    ],
+    [
+      "chance to drop an additional enkindling orb",
+      "enkindling orb"
+    ],
+    [
+      "chance to drop an additional instilling orb",
+      "instilling orb"
+    ],
+    [
+      "chance to drop an additional orb of regret",
+      "orb of regret"
+    ],
+    [
+      "chance to drop an additional glassblower's bauble",
+      "glassblower's bauble"
+    ],
+    [
+      "chance to drop an additional gemcutter's prism",
+      "gemcutter's prism"
+    ],
+    [
+      "chance to drop an additional chaos orb",
+      "chaos orb"
+    ],
+    [
+      "chance to drop an additional divination card which rewards a unique weapon",
+      "div card: unique weapon"
+    ],
+    [
+      "chance to drop an additional divination card which rewards a unique armour",
+      "div card: unique armour"
+    ],
+    [
+      "chance to drop an additional divination card which rewards unique jewellery",
+      "div card: unique jewellery"
+    ],
+    [
+      "chance to drop an additional divination card which rewards a corrupted unique item",
+      "div card: corrupted unique item"
+    ],
+    [
+      "chance to drop an additional divination card which rewards a map",
+      "div card: map"
+    ],
+    [
+      "chance to drop an additional divination card which rewards a unique map",
+      "div card: unique map"
+    ],
+    [
+      "chance to drop an additional divination card which rewards a corrupted item",
+      "div card: corrupted item"
+    ],
+    [
+      "chance to drop an additional breach scarab",
+      "breach scarab"
+    ],
+    [
+      "chance to drop an additional delirium scarab",
+      "delirium scarab"
+    ],
+    [
+      "chance to drop an additional legion scarab",
+      "legion scarab"
+    ],
+    [
+      "chance to drop an additional blight scarab",
+      "blight scarab"
+    ],
+    [
+      "chance to drop an additional ritual scarab",
+      "ritual scarab"
+    ],
+    [
+      "chance to drop an additional harvest scarab",
+      "harvest scarab"
+    ],
+    [
+      "chance to drop an additional ultimatum scarab",
+      "ultimatum scarab"
+    ],
+    [
+      "chance to drop an additional abyss scarab",
+      "abyss scarab"
+    ],
+    [
+      "chance to drop an additional expedition scarab",
+      "expedition scarab"
+    ],
+    [
+      "chance to drop an additional betrayal scarab",
+      "betrayal scarab"
+    ],
+    [
+      "chance to drop an additional bestiary scarab",
+      "bestiary scarab"
+    ],
+    [
+      "chance to drop an additional incursion scarab",
+      "incursion scarab"
+    ],
+    [
+      "chance to drop an additional sulphite scarab",
+      "sulphite scarab"
+    ],
+    [
+      "chance to drop an additional influence scarab",
+      "influence scarab"
+    ],
+    [
+      "chance to drop an additional cartography scarab",
+      "cartography scarab"
+    ],
+    [
+      "chance to drop an additional divination scarab",
+      "divination scarab"
+    ],
+    [
+      "chance to drop an additional anarchy scarab",
+      "anarchy scarab"
+    ],
+    [
+      "chance to drop an additional harbinger scarab",
+      "harbinger scarab"
+    ],
+    [
+      "[dnt] chance to drop an additional miscellaneous scarab",
+      "miscellaneous scarab"
+    ],
+    [
+      "chance to drop an additional beyond scarab",
+      "beyond scarab"
+    ],
+    [
+      "chance to drop an additional torment scarab",
+      "torment scarab"
+    ],
+    [
+      "chance to drop an additional ambush scarab",
+      "ambush scarab"
+    ],
+    [
+      "chance to drop an additional domination scarab",
+      "domination scarab"
+    ],
+    [
+      "chance to drop an additional essence scarab",
+      "essence scarab"
+    ],
+    [
+      "chance to drop an additional reliquary scarab",
+      "reliquary scarab"
+    ]
+  ],
+  "player": [
+    [
+      "- to cold resistance\r\n- to lightning resistance",
+      "–cold & –lightning res"
+    ],
+    [
+      "- additional physical damage reduction",
+      "–additional pdr"
+    ],
+    [
+      "reduced defences per frenzy charge",
+      "–defences per f-charge"
+    ],
+    [
+      "reduced recovery rate of life, mana and energy shield per endurance charge",
+      "–life/mana/es recovery per e-charge"
+    ],
+    [
+      "- to critical strike multiplier per power charge",
+      "–crit multi per p-charge"
+    ],
+    [
+      "chance for enemies to drop chilled ground when hitting you, no more than once every seconds",
+      "chance: chilled ground when hit"
+    ],
+    [
+      "chance for enemies to drop shocked ground when hitting you, no more than once every seconds",
+      "chance: shocked ground when hit"
+    ],
+    [
+      "all damage taken from hits can sap you\r\nchance to be sapped when hit",
+      "chance to be sapped when hit"
+    ],
+    [
+      "nearby enemies gain of their physical damage as extra cold damage",
+      "nearby enemies: phys as extra cold dmg"
+    ],
+    [
+      "nearby enemies gain of their physical damage as extra lightning damage",
+      "nearby enemies: phys as extra lightning dmg"
+    ],
+    [
+      "projectiles are fired in random directions",
+      "random projectiles"
+    ],
+    [
+      "non-damaging ailments you inflict are reflected back to you",
+      "non-dmg ailments are reflected"
+    ],
+    [
+      "- to fire resistance\r\n- to chaos resistance",
+      "–fire & –chaos res"
+    ],
+    [
+      "- to armour\r\n- to evasion rating",
+      "–armour/evasion"
+    ],
+    [
+      "increased flask charges used\r\nreduced flask effect duration",
+      "flasks: +cost/–duration"
+    ],
+    [
+      "take chaos damage per second during any flask effect",
+      "chaos dot during any flask effect"
+    ],
+    [
+      "all damage taken from hits can scorch you\r\nchance to be scorched when hit",
+      "chance to be scorched when hit"
+    ],
+    [
+      "curses you inflict are reflected back to you",
+      "curses are reflected"
+    ],
+    [
+      "chance for enemies to drop burning ground when hitting you, no more than once every seconds",
+      "chance: burning ground when hit"
+    ],
+    [
+      "chance to be targeted by a meteor when you use a flask",
+      "chance: meteor on flask"
+    ],
+    [
+      "nearby enemies gain of their physical damage as extra fire damage",
+      "nearby enemies: phys as extra fire dmg"
+    ],
+    [
+      "nearby enemies gain of their physical damage as extra chaos damage",
+      "nearby enemies: phys as extra chaos dmg"
+    ],
+    [
+      "basic currency items dropped by slain enemies have chance to be duplicated",
+      "dupe chance: basic currency"
+    ],
+    [
+      "unique items dropped by slain enemies have chance to be duplicated",
+      "dupe chance: unique"
+    ],
+    [
+      "scarabs dropped by slain enemies have chance to be duplicated",
+      "dupe chance: scarabs"
+    ],
+    [
+      "maps dropped by slain enemies have chance to be duplicated",
+      "dupe chance: maps"
+    ],
+    [
+      "divination cards dropped by slain enemies have chance to be duplicated",
+      "dupe chance: div cards"
+    ],
+    [
+      "increased quantity of items found in this area\r\nincreased rarity of items found in this area",
+      "inc quantity & rarity"
+    ],
+    [
+      "gems dropped by slain enemies have chance to be duplicated",
+      "dupe chance: gems"
+    ],
+    [
+      "increased quantity of items found in this area",
+      "inc quantity"
+    ],
+    [
+      "increased rarity of items found in this area",
+      "inc rarity"
+    ],
+    [
+      "increased experience gain",
+      "inc experience gain"
+    ]
+  ]
+}

--- a/data/english/map-info.txt
+++ b/data/english/map-info.txt
@@ -100,7 +100,7 @@ type	=	player
 text	=	no regen
 ID	=	003
 
-[cannot leech # from monsters]
+[Monsters cannot be Leeched from]
 type	=	player
 text	=	no leech
 ID	=	004
@@ -110,9 +110,9 @@ type	=	player
 text	=	temp chains
 ID	=	005
 
-[# maximum player resistances]
+[players have # to all maximum resistances]
 type	=	player
-text	=	max res: -%
+text	=	all max res: -%
 ID	=	006
 
 [players have # less recovery rate of life and energy shield]
@@ -200,12 +200,12 @@ type	=	monsters
 text	=	poison on hit
 ID	=	023
 
-[monsters cannot be taunted|monsters' action speed cannot be modified to below base value]
+[monsters cannot be taunted|monsters' action speed cannot be modified to below base value|monsters' movement speed cannot be modified to below base value]
 type	=	monsters
 text	=	slow/taunt immune
 ID	=	024
 
-[monsters have # chance to impale with attacks]
+[monsters' attacks have # chance to impale on hit]
 type	=	monsters
 text	=	impale chance: %
 ID	=	025
@@ -490,7 +490,7 @@ type	=	monsters
 text	=	rare mobs: +%
 ID	=	081
 
-[monsters deal # extra physical damage as chaos]
+[Monsters gain # of their Physical Damage as Extra Chaos Damage]
 type	=	monsters
 text	=	phys as chaos: %
 ID	=	082
@@ -509,6 +509,16 @@ ID	=	084
 type	=	bosses
 text	=	all at once
 ID	=	085
+
+[Monsters have a # chance Ignite, Freeze and Shock on Hit]
+type	=	monsters
+text	=	ignite, freeze, shock: %
+ID	=	086
+
+[Monsters have a # chance to Ignite, Freeze and Shock on Hit]
+type	=	monsters
+text	=	ignite, freeze, shock: %
+ID	=	086
 
 [monsters have # chance to gain a frenzy charge on hit]
 type	=	monsters

--- a/data/versions.json
+++ b/data/versions.json
@@ -1,4 +1,4 @@
 {
   "_release": [15204, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"],
-  "hotfix": 1
+  "hotfix": 2
 }

--- a/modules/map-info.ahk
+++ b/modules/map-info.ahk
@@ -284,6 +284,11 @@ MapinfoParse(mode := 1)
 			}
 			If check && mods.HasKey(check)
 				map_mods[check] := value
+			Else If check && settings.general.dev
+			{
+				Clipboard := check
+				MsgBox, % check
+			}
 		}
 		Else If InStr(A_LoopField, " (enchant)")
 		{


### PR DESCRIPTION
- hotfix 1: regex fix for sacrifice and sacred wisps (leveltracker)
- hotfix 1: add missing necropolis league color, and support for portal scroll hotkey (maptracker)
- hotfix 2: add support for reworded/new map mods (map-info)
- hotfix 2: add support for new eldritch altars (tldr-tooltips)
- necropolis (3.24) updates: betrayal-info, horizon-tooltips, item-info
- GENERAL REMINDER: SCREEN-CHECKS MAY NEED RECALIBRATION AFTER MAJOR GAME PATCHES. IF THE OMNI-KEY DOESN'T WORK ANYMORE, TEST THE CHECKS AND RECALIBRATE IF NECESSARY
- leveling tracker: changed effective exp panel, improved gem-regex
- fix: leveling tracker doesn't stay hidden after campaign completion
- fix: tldr-tooltips would also screen-cap overlays that potentially cover text