### PR TITLE
v1.52.5 (Hotfix 1) merge

### DIFF
--- a/data/changelog.json
+++ b/data/changelog.json
@@ -1,6 +1,8 @@
 [
   [
 	["1.52.5", 15205],
+	"hotfix 1: fixed bug with hint-images on multi-monitors (leveling tracker)",
+	"hotfix 1: added support for 3.24 exile-leveling guides",
 	"fix: horizons-tooltips always showed 100% e-exp when used in town/hideout",
 	"item-info: updated unique drop-tiers",
 	"new experimental feature: necropolis lantern highlighting"

--- a/data/english/[leveltracker] areas.json
+++ b/data/english/[leveltracker] areas.json
@@ -506,7 +506,7 @@
       "1_2_14_3"
     ],
     "crafting_recipes": [
-      "Movement Speed - Rank 1"
+      "Vaal Skill Damage - Rank 1"
     ]
   },
   "1_2_5_1": {
@@ -577,7 +577,9 @@
       "1_2_14_3",
       "1_3_town"
     ],
-    "crafting_recipes": []
+    "crafting_recipes": [
+      "Movement Speed - Rank 1"
+    ]
   },
   "1_3_town": {
     "id": "1_3_town",
@@ -984,7 +986,9 @@
     "connection_ids": [
       "1_3_17_1"
     ],
-    "crafting_recipes": []
+    "crafting_recipes": [
+      "Life and Mana Regeneration - Rank 1"
+    ]
   },
   "1_3_18_2": {
     "id": "1_3_18_2",

--- a/data/english/[leveltracker] gems.json
+++ b/data/english/[leveltracker] gems.json
@@ -991,14 +991,6 @@
     "is_support": true,
     "cost": "wisdom"
   },
-  "Metadata/Items/Gems/SupportGemVolatility": {
-    "id": "Metadata/Items/Gems/SupportGemVolatility",
-    "name": "Volatility Support",
-    "primary_attribute": "strength",
-    "required_level": 18,
-    "is_support": true,
-    "cost": "alteration"
-  },
   "Metadata/Items/Gems/SupportGemBloodMagic": {
     "id": "Metadata/Items/Gems/SupportGemBloodMagic",
     "name": "Arrogance Support",
@@ -1774,6 +1766,14 @@
     "required_level": 24,
     "is_support": false,
     "cost": "alteration"
+  },
+  "Metadata/Items/Gems/SkillGemConvocationNew": {
+    "id": "Metadata/Items/Gems/SkillGemConvocationNew",
+    "name": "Convocation",
+    "primary_attribute": "intelligence",
+    "required_level": 31,
+    "is_support": false,
+    "cost": "chance"
   },
   "Metadata/Items/Gems/SkillGemFireNovaMine": {
     "id": "Metadata/Items/Gems/SkillGemFireNovaMine",
@@ -4215,14 +4215,6 @@
     "is_support": true,
     "cost": "chance"
   },
-  "Metadata/Items/Gems/SupportGemConflagration": {
-    "id": "Metadata/Items/Gems/SupportGemConflagration",
-    "name": "[UNUSED] Conflagration Support",
-    "primary_attribute": "strength",
-    "required_level": 18,
-    "is_support": true,
-    "cost": "alteration"
-  },
   "Metadata/Items/Gems/SupportGemGuardiansBlessing": {
     "id": "Metadata/Items/Gems/SupportGemGuardiansBlessing",
     "name": "Guardian's Blessing Support",
@@ -4270,5 +4262,37 @@
     "required_level": 31,
     "is_support": true,
     "cost": "chance"
+  },
+  "Metadata/Items/Gems/SupportGemVolatility": {
+    "id": "Metadata/Items/Gems/SupportGemVolatility",
+    "name": "Volatility Support",
+    "primary_attribute": "strength",
+    "required_level": 18,
+    "is_support": true,
+    "cost": "alteration"
+  },
+  "Metadata/Items/Gems/SkillGemAutomation": {
+    "id": "Metadata/Items/Gems/SkillGemAutomation",
+    "name": "Automation",
+    "primary_attribute": "intelligence",
+    "required_level": 24,
+    "is_support": false,
+    "cost": "alteration"
+  },
+  "Metadata/Items/Gems/SkillGemCallToArms": {
+    "id": "Metadata/Items/Gems/SkillGemCallToArms",
+    "name": "Call to Arms",
+    "primary_attribute": "strength",
+    "required_level": 24,
+    "is_support": false,
+    "cost": "alteration"
+  },
+  "Metadata/Items/Gems/SupportGemSacredWisps": {
+    "id": "Metadata/Items/Gems/SupportGemSacredWisps",
+    "name": "Sacred Wisps Support",
+    "primary_attribute": "intelligence",
+    "required_level": 18,
+    "is_support": true,
+    "cost": "alteration"
   }
 }

--- a/data/english/[leveltracker] quests.json
+++ b/data/english/[leveltracker] quests.json
@@ -2969,6 +2969,15 @@
             "classes": [],
             "npc": "Yeena"
           },
+          "Metadata/Items/Gems/SkillGemPoachersMark": {
+            "classes": [
+              "Shadow",
+              "Duelist",
+              "Ranger",
+              "Scion"
+            ],
+            "npc": "Yeena"
+          },
           "Metadata/Items/Gems/SkillGemRighteousFire": {
             "classes": [
               "Marauder",
@@ -3007,30 +3016,21 @@
             ],
             "npc": "Yeena"
           },
-          "Metadata/Items/Gems/SkillGemPurge": {
-            "classes": [
-              "Scion",
-              "Shadow",
-              "Templar",
-              "Witch"
-            ],
-            "npc": "Yeena"
-          },
-          "Metadata/Items/Gems/SkillGemPoachersMark": {
-            "classes": [
-              "Shadow",
-              "Duelist",
-              "Ranger",
-              "Scion"
-            ],
-            "npc": "Yeena"
-          },
           "Metadata/Items/Gems/SkillGemWarlordsMark": {
             "classes": [
               "Marauder",
               "Duelist",
               "Ranger",
               "Scion"
+            ],
+            "npc": "Yeena"
+          },
+          "Metadata/Items/Gems/SkillGemPurge": {
+            "classes": [
+              "Scion",
+              "Shadow",
+              "Templar",
+              "Witch"
             ],
             "npc": "Yeena"
           }
@@ -3143,6 +3143,11 @@
             ]
           },
           "Metadata/Items/Gems/SupportGemFreshMeat": {
+            "classes": [
+              "Witch"
+            ]
+          },
+          "Metadata/Items/Gems/SupportGemSacredWisps": {
             "classes": [
               "Witch"
             ]
@@ -3474,6 +3479,15 @@
             ],
             "npc": "Yeena"
           },
+          "Metadata/Items/Gems/SupportGemSacredWisps": {
+            "classes": [
+              "Ranger",
+              "Scion",
+              "Templar",
+              "Witch"
+            ],
+            "npc": "Yeena"
+          },
           "Metadata/Items/Gems/SupportGemSadism": {
             "classes": [],
             "npc": "Yeena"
@@ -3727,11 +3741,6 @@
               "Witch"
             ]
           },
-          "Metadata/Items/Gems/SkillGemConvocation": {
-            "classes": [
-              "Witch"
-            ]
-          },
           "Metadata/Items/Gems/SkillGemDamageOverTimeAura": {
             "classes": [
               "Witch",
@@ -3876,6 +3885,10 @@
             ],
             "npc": "Clarissa"
           },
+          "Metadata/Items/Gems/SkillGemAutomation": {
+            "classes": [],
+            "npc": "Clarissa"
+          },
           "Metadata/Items/Gems/SkillGemDarkRitual": {
             "classes": [
               "Scion",
@@ -3886,6 +3899,15 @@
             "npc": "Clarissa"
           },
           "Metadata/Items/Gems/SkillGemBattlemagesCry": {
+            "classes": [
+              "Duelist",
+              "Marauder",
+              "Scion",
+              "Templar"
+            ],
+            "npc": "Clarissa"
+          },
+          "Metadata/Items/Gems/SkillGemCallToArms": {
             "classes": [
               "Duelist",
               "Marauder",
@@ -3905,8 +3927,6 @@
           },
           "Metadata/Items/Gems/SkillGemConvocation": {
             "classes": [
-              "Scion",
-              "Templar",
               "Witch"
             ],
             "npc": "Clarissa"
@@ -5335,6 +5355,10 @@
             "classes": [],
             "npc": "Siosa"
           },
+          "Metadata/Items/Gems/SkillGemAutomation": {
+            "classes": [],
+            "npc": "Siosa"
+          },
           "Metadata/Items/Gems/SkillGemBallLightning": {
             "classes": [],
             "npc": "Siosa"
@@ -5448,6 +5472,10 @@
             "npc": "Siosa"
           },
           "Metadata/Items/Gems/SupportGemIncreasedBurningDamage": {
+            "classes": [],
+            "npc": "Siosa"
+          },
+          "Metadata/Items/Gems/SkillGemCallToArms": {
             "classes": [],
             "npc": "Siosa"
           },
@@ -6368,6 +6396,10 @@
             "npc": "Siosa"
           },
           "Metadata/Items/Gems/SupportGemRuthless": {
+            "classes": [],
+            "npc": "Siosa"
+          },
+          "Metadata/Items/Gems/SupportGemSacredWisps": {
             "classes": [],
             "npc": "Siosa"
           },
@@ -8161,6 +8193,10 @@
             "classes": [],
             "npc": "Lilly Roth"
           },
+          "Metadata/Items/Gems/SkillGemAutomation": {
+            "classes": [],
+            "npc": "Lilly Roth"
+          },
           "Metadata/Items/Gems/SkillGemBallLightning": {
             "classes": [],
             "npc": "Lilly Roth"
@@ -8294,6 +8330,10 @@
             "npc": "Lilly Roth"
           },
           "Metadata/Items/Gems/SupportGemIncreasedBurningDamage": {
+            "classes": [],
+            "npc": "Lilly Roth"
+          },
+          "Metadata/Items/Gems/SkillGemCallToArms": {
             "classes": [],
             "npc": "Lilly Roth"
           },
@@ -9117,10 +9157,6 @@
             "classes": [],
             "npc": "Lilly Roth"
           },
-          "Metadata/Items/Gems/SupportGemOnslaught": {
-            "classes": [],
-            "npc": "Lilly Roth"
-          },
           "Metadata/Items/Gems/SupportGemMultiTotem": {
             "classes": [],
             "npc": "Lilly Roth"
@@ -9290,6 +9326,10 @@
             "npc": "Lilly Roth"
           },
           "Metadata/Items/Gems/SkillGemMagmaOrb": {
+            "classes": [],
+            "npc": "Lilly Roth"
+          },
+          "Metadata/Items/Gems/SupportGemSacredWisps": {
             "classes": [],
             "npc": "Lilly Roth"
           },
@@ -10623,12 +10663,6 @@
     "act": "12",
     "reward_offers": {}
   },
-  "heist_intro": {
-    "id": "heist_intro",
-    "name": "The Rogue Harbour",
-    "act": "6",
-    "reward_offers": {}
-  },
   "maven_atlas": {
     "id": "maven_atlas",
     "name": "The Maven",
@@ -10717,70 +10751,6 @@
       }
     }
   },
-  "ritual_tutorial": {
-    "id": "ritual_tutorial",
-    "name": "Paying Tribute",
-    "act": "1",
-    "reward_offers": {}
-  },
-  "trialmaster_tutorial": {
-    "id": "trialmaster_tutorial",
-    "name": "A Choice of Futures",
-    "act": "1",
-    "reward_offers": {}
-  },
-  "expedition_tutorial": {
-    "id": "expedition_tutorial",
-    "name": "Unearthing the Past",
-    "act": "6",
-    "reward_offers": {}
-  },
-  "expedition_tutorial2": {
-    "id": "expedition_tutorial2",
-    "name": "Explosive Archaeology",
-    "act": "6",
-    "reward_offers": {}
-  },
-  "expedition_mainquest": {
-    "id": "expedition_mainquest",
-    "name": "The Lost Expedition",
-    "act": "6",
-    "reward_offers": {}
-  },
-  "hellscape_tutorial1": {
-    "id": "hellscape_tutorial1",
-    "name": "A Glimpse Beyond",
-    "act": "1",
-    "reward_offers": {
-      "hellscape_tutorial1": {
-        "quest_npc": "The Last to Die",
-        "quest": {
-          "Metadata/Items/QuestItems/Hellscape/BloodCrucible": {
-            "classes": []
-          }
-        },
-        "vendor": {}
-      }
-    }
-  },
-  "hellscape_tutorial2": {
-    "id": "hellscape_tutorial2",
-    "name": "Thirst for Blood",
-    "act": "1",
-    "reward_offers": {}
-  },
-  "hellscape_tutorial3": {
-    "id": "hellscape_tutorial3",
-    "name": "Twisted Dreams",
-    "act": "11",
-    "reward_offers": {}
-  },
-  "hellscape_tutorial4": {
-    "id": "hellscape_tutorial4",
-    "name": "Altered Flesh",
-    "act": "11",
-    "reward_offers": {}
-  },
   "kirac_atlas": {
     "id": "kirac_atlas",
     "name": "The Atlas of Worlds",
@@ -10789,45 +10759,21 @@
       "atlas": {
         "quest_npc": "Commander Kirac",
         "quest": {
-          "Metadata/Items/Maps/MapWorldsArena": {
+          "Metadata/Items/Maps/MapWorldsCrimsonTownship": {
             "classes": []
           },
-          "Metadata/Items/Maps/MapWorldsBarrows": {
+          "Metadata/Items/Maps/MapWorldsShipyard": {
             "classes": []
           },
           "Metadata/Items/Maps/MapWorldsBoneCrypt": {
             "classes": []
           },
-          "Metadata/Items/Maps/MapWorldsPlateau": {
+          "Metadata/Items/Maps/MapWorldsDesertSpring": {
             "classes": []
           }
         },
         "vendor": {}
       }
     }
-  },
-  "archnemesis_tutorial": {
-    "id": "archnemesis_tutorial",
-    "name": "Archnemesis",
-    "act": "1",
-    "reward_offers": {}
-  },
-  "sentinel_tutorial": {
-    "id": "sentinel_tutorial",
-    "name": "Sentinel",
-    "act": "1",
-    "reward_offers": {}
-  },
-  "lake_tutorial": {
-    "id": "lake_tutorial",
-    "name": "Lake of Kalandra",
-    "act": "1",
-    "reward_offers": {}
-  },
-  "ancestral_tutorial": {
-    "id": "ancestral_tutorial",
-    "name": "Dying for a Fight",
-    "act": "1",
-    "reward_offers": {}
   }
 }

--- a/data/global/[leveltracker] gem regex.json
+++ b/data/global/[leveltracker] gem regex.json
@@ -111,6 +111,10 @@
     "ass.*ark",
     "3"
   ],
+  "Automation": [
+    "aut.*ion",
+    "3"
+  ],
   "Ball Lightning": [
     "bal.*ing",
     "3"
@@ -245,6 +249,10 @@
   ],
   "Burning Damage Support": [
     "bur.*rt",
+    "1"
+  ],
+  "Call to Arms": [
+    "cal.*rms",
     "1"
   ],
   "Cast On Critical Strike Support": [
@@ -1314,6 +1322,10 @@
   "Ruthless Support": [
     "rut.*rt",
     "1"
+  ],
+  "Sacred Wisps Support": [
+    "sacre.*rt",
+    "3"
   ],
   "Sacrifice Support": [
     "sacri.*rt",

--- a/data/versions.json
+++ b/data/versions.json
@@ -1,3 +1,4 @@
 {
-  "_release": [15205, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"]
+  "_release": [15205, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"],
+  "hofix": 1
 }

--- a/modules/leveling tracker.ahk
+++ b/modules/leveling tracker.ahk
@@ -481,7 +481,7 @@ LeveltrackerHints()
 		Gui, leveltracker_hints: Show, NA x10000 y10000
 		WinGetPos,,, w, h, ahk_id %leveltracker_hints%
 		yPos := (Blank(settings.leveltracker.yCoord) || settings.leveltracker.yCoord >= vars.monitor.h / 2) ? vars.leveltracker.coords.y1 - h + 1 : vars.leveltracker.coords.y2 - 1
-		Gui, leveltracker_hints: Show, % "NA x"vars.leveltracker.coords.x1 " y" yPos
+		Gui, leveltracker_hints: Show, % "NA x" vars.monitor.x + vars.leveltracker.coords.x1 " y" yPos
 	}
 	KeyWait, % settings.hotkeys.tab
 	Gui, leveltracker_hints: Destroy


### PR DESCRIPTION
- fix: horizons-tooltips always showed 100% e-exp when used in town/hideout
- item-info: updated unique drop-tiers
- new experimental feature: necropolis lantern highlighting
- hotfix 1: fixed hint-images being misplaced on specific multi-monitor setups
- hotfix 1: added support for 3.24 exile-leveling guides