### PR TITLE
v1.53.2 (Hotfix 1) merge

### DIFF
--- a/Lailloken UI.ahk
+++ b/Lailloken UI.ahk
@@ -172,14 +172,16 @@ FormatSeconds(seconds, mode := 1)  ; Convert the specified number of seconds to 
 	return time
 }
 
-LLK_HasKey(object, value, InStr := 0, case_sensitive := 0, all_results := 0)
+LLK_HasKey(object, value, InStr := 0, case_sensitive := 0, all_results := 0, recurse := 0)
 {
 	local
 
+	If !IsObject(object) || Blank(value)
+		Return
 	parse := []
 	For key, val in object
 	{
-		If (key = value) || InStr && InStr(key, value, case_sensitive)
+		If (key = value) || InStr && InStr(key, value, case_sensitive) || recurse && IsObject(val) && LLK_HasKey(val, value, InStr, case_sensitive, all_results, recurse)
 		{
 			If !all_results
 				Return key

--- a/data/changelog.json
+++ b/data/changelog.json
@@ -1,7 +1,7 @@
 [
   [
 	["1.53.2", 15302],
-	"hotfix 1: items with <scarab> in their name activated stash-ninja when omni-clicked",
+	"hotfix 1: omni-key activated the stash-ninja feature when pressed on items with <scarab> in their names",
 	"stash-ninja: added optional price history/trend",
 	"stash-ninja: added optional bulk-sale suggestions",
 	"some minor fixes and additions"

--- a/data/changelog.json
+++ b/data/changelog.json
@@ -1,6 +1,7 @@
 [
   [
 	["1.53.2", 15302],
+	"hotfix 1: items with <scarab> in their name activated stash-ninja when omni-clicked",
 	"stash-ninja: added optional price history/trend",
 	"stash-ninja: added optional bulk-sale suggestions",
 	"some minor fixes and additions"

--- a/data/versions.json
+++ b/data/versions.json
@@ -1,3 +1,4 @@
 {
-  "_release": [15302, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"]
+  "_release": [15302, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"],
+  "hotfix": 1
 }

--- a/modules/omni-key.ahk
+++ b/modules/omni-key.ahk
@@ -258,17 +258,13 @@ OmniContext(mode := 0)
 		If settings.features.mapinfo
 			Return "mapinfo"
 	}
-	If settings.features.stash && InStr(item.name, "scarab")
+	If settings.features.stash
 	{
-		start := A_TickCount
-		While GetKeyState(ThisHotkey_copy, "P")
+		check := LLK_HasKey(vars.stash, item.name,,,, 1), start := A_TickCount
+		While check && GetKeyState(ThisHotkey_copy, "P")
 			If (A_TickCount >= start + 150)
 			{
-				Stash_("scarabs")
-				;SendInput, % "{" ThisHotkey_copy " UP}"
-				;KeyWait, % ThisHotkey_copy
-				;LLK_Overlay(vars.hwnd.stash.main, "destroy")
-				;vars.stash.GUI := vars.stash.hover := 0
+				Stash_(check)
 				Return
 			}
 	}


### PR DESCRIPTION
- fixed an oversight where a long omni-click on items with "scarab" in their names would activate the Stash-Ninja feature