### PR TITLE
v1.53.4 (Hotfix 1) merge

### DIFF
--- a/data/changelog.json
+++ b/data/changelog.json
@@ -1,6 +1,7 @@
 [
   [
 	["1.53.4", 15304],
+	"hotfix 1: help tooltips were displayed incorrectly if settings menu was in center position",
 	"stash-ninja: bulk-sale improvements, added support for tabs within folders",
 	"stash-ninja: now supports every type of stash tab"
   ],

--- a/data/global/[stash-ninja] tabs.json
+++ b/data/global/[stash-ninja] tabs.json
@@ -46,7 +46,7 @@
 		[240, 185, "tab_currency1"],
 		[466, 0, "tab_currency2"],
 		[47, 248, "scroll fragment"],
-		[0, 0, "wisdom scroll"],
+		[0, 0, "scroll of wisdom"],
 		[0, 0, "portal scroll"],
 		[299, 0, "enkindling orb"],
 		[0, 0, "instilling orb"],

--- a/data/versions.json
+++ b/data/versions.json
@@ -1,3 +1,4 @@
 {
-  "_release": [15304, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"]
+  "_release": [15304, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"],
+  "hotfix": 1
 }

--- a/modules/settings menu.ahk
+++ b/modules/settings menu.ahk
@@ -2174,7 +2174,7 @@ Settings_menu(section, mode := 0, NA := 1) ;mode parameter is used when manually
 	Else
 	{
 		Gui, %GUI_name%: Show, % "NA x" vars.monitor.x + vars.client.xc - w//2 " y" vars.monitor.y + vars.client.yc - h//2 " w"w - 1 " h"h - 2
-		vars.settings.x := vars.client.x
+		vars.settings.x := vars.client.x + vars.client.xc - w//2
 	}
 	LLK_Overlay(vars.hwnd.settings.main, "show", NA, GUI_name), LLK_Overlay(hwnd_old, "destroy"), vars.settings.w := w, vars.settings.h := h, vars.settings.restart := vars.settings.wait := vars.settings.color := ""
 }


### PR DESCRIPTION
- help tooltips were displayed incorrectly if the settings menu was in its (recently updated) default position, i.e. in the center of the client-area