### PR TITLE
v1.53.5 (Hotfix 1) merge

### DIFF
--- a/data/changelog.json
+++ b/data/changelog.json
@@ -1,6 +1,7 @@
 [
   [
 	["1.53.5", 15305],
+	"hotfix 1: stash-ninja was activated by rare items that had the same name as tab-specific items",
 	"restored geforce now compatibility",
 	"added optional hotkeys to switch between leveling tracker guide-pages",
 	"stash-ninja: price history fix, custom stock for unstackable items"

--- a/data/versions.json
+++ b/data/versions.json
@@ -1,3 +1,4 @@
 {
-  "_release": [15305, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"]
+  "_release": [15305, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"],
+  "hotfix": 1
 }

--- a/modules/omni-key.ahk
+++ b/modules/omni-key.ahk
@@ -268,7 +268,7 @@ OmniContext(mode := 0)
 	If settings.features.stash
 	{
 		check := LLK_HasKey(vars.stash, item.name,,,, 1), start := A_TickCount
-		While check && GetKeyState(ThisHotkey_copy, "P")
+		While check && (Blank(item.itembase) || item.name = item.itembase) && GetKeyState(ThisHotkey_copy, "P")
 			If (A_TickCount >= start + 150)
 			{
 				Stash_(check)


### PR DESCRIPTION
- hotfix 1: stash-ninja was activated by rare items that had the same name as tab-specific items (e.g. abyss jewels with the name "ancient orb")