### PR TITLE
v1.54.0 (Hotfix 1) merge

### DIFF
--- a/data/changelog.json
+++ b/data/changelog.json
@@ -1,6 +1,7 @@
 [
   [
 	["1.54.0", 15400],
+	"hotfix 1: map-tracker's <stash> image-check failed when it was the only active check",
 	"stash-ninja: added support for official bulk-exchange prices",
 	"stash-ninja: streamlined bulk-sale management"
   ],

--- a/data/versions.json
+++ b/data/versions.json
@@ -1,3 +1,4 @@
 {
-  "_release": [15400, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"]
+  "_release": [15400, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"],
+  "hotfix": 1
 }

--- a/modules/leveling tracker.ahk
+++ b/modules/leveling tracker.ahk
@@ -770,8 +770,13 @@ LeveltrackerImport(profile := "")
 	guide_text := StrReplace(guide_text, "enter (img:arena) arena:shavronne's_sorrow , kill shavronne `n", "kill doedre , (color:FF8111)maligaro , (color:FF8111)shavronne`n")
 	guide_text := StrReplace(guide_text, "talk to sin, enter (img:arena)", "enter (img:arena)"), guide_text := StrReplace(guide_text, "activate the (img:craft) `ntalk", "activate the (img:craft) , talk")
 	StringLower, guide_text, guide_text
-	IniDelete, ini\leveling guide%profile%.ini, Steps
-	IniDelete, ini\leveling guide%profile%.ini, Info
+	If !FileExist("ini\leveling guide" profile ".ini")
+		IniWrite, % "", ini\leveling guide%profile%.ini, Steps
+	Else
+	{
+		IniDelete, ini\leveling guide%profile%.ini, Steps
+		IniDelete, ini\leveling guide%profile%.ini, Info
+	}
 	IniWrite, % guide_text, ini\leveling guide%profile%.ini, Steps
 
 	Settings_menu("leveling tracker")

--- a/modules/screen-checks.ahk
+++ b/modules/screen-checks.ahk
@@ -157,8 +157,8 @@ Screenchecks_ImageSearch(name := "") ;performing image screen-checks: use parame
 	For key, val in vars.imagesearch.search
 		vars.imagesearch[val].check := 0 ;reset results for all checks
 	check := 0
-	For index, val in ["betrayal", "leveltracker", "necropolis"]
-		check += settings.features[val]
+	For index, val in ["betrayal", "leveltracker", "necropolis", "maptracker"]
+		check += (val = "maptracker") ? settings.features.maptracker * settings.maptracker.loot : settings.features[val]
 	If !check
 		Return
 


### PR DESCRIPTION
- map-tracker's <stash> image-check failed when it was the only active check
- act-tracker: preventative measure for instances where guide-data is stored in ini-files with incorrect file encoding