### PR TITLE
v1.54.4 (Hotfix 2) merge

### DIFF
--- a/data/changelog.json
+++ b/data/changelog.json
@@ -2,7 +2,8 @@
   [
 	["1.54.4", 15404],
 	"some league-launch announcements: read full changelog",
-	"hotfix 1: updated & re-enabled stash-ninja, updated essence tooltips, added new t17 fracture map-mod"
+	"hotfix 1: updated & re-enabled stash-ninja, updated essence tooltips, added new t17 fracture map-mod",
+	"hotfix 2: lab-trials were treated as maps and bricked the current log"
   ],
   [
 	["1.54.3", 15403],

--- a/data/versions.json
+++ b/data/versions.json
@@ -1,4 +1,4 @@
 {
   "_release": [15404, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"],
-  "hotfix": 1
+  "hotfix": 2
 }

--- a/modules/map tracker.ahk
+++ b/modules/map tracker.ahk
@@ -145,7 +145,7 @@ MaptrackerCheck(mode := 0) ;checks if player is in a map or map-related content:
 	global vars, settings
 
 	mode_check := ["abyssleague", "endgame_labyrinth_trials", "mapsidearea"]
-	For key, val in {"mapworlds": 0, "maven": 0, "betrayal": 0, "incursion": 0, "heist": "heisthub", "mapatziri": 0, "legionleague": 0, "expedition": 0, "atlasexilesboss": 0, "breachboss": 0, "affliction": 0, "bestiary": 0, "sanctum": "sanctumfoyer", "synthesis": 0, "abyssleague": 0, "labyrinth_trials": 0, "mapsidearea": 0}
+	For key, val in {"mapworlds": 0, "maven": 0, "betrayal": 0, "incursion": 0, "heist": "heisthub", "mapatziri": 0, "legionleague": 0, "expedition": 0, "atlasexilesboss": 0, "breachboss": 0, "affliction": 0, "bestiary": 0, "sanctum": "sanctumfoyer", "synthesis": 0, "abyssleague": 0, "endgame_labyrinth_trials": 0, "mapsidearea": 0}
 	{
 		If !mode && !Blank(LLK_HasVal(mode_check, key)) || (mode = 1) && Blank(LLK_HasVal(mode_check, key))
 			Continue


### PR DESCRIPTION
- map-tracker: lab-trials were treated as maps and bricked the current log