### PR TITLE
v1.54.7 (Hotfix 1) merge

### DIFF
--- a/data/changelog.json
+++ b/data/changelog.json
@@ -1,6 +1,7 @@
 [
   [
 	["1.54.7", 15407],
+	"hotfix 1: highlighting thresholds for rarity and pack-size were swapped around (map-info)",
 	"added support for non-standard keyboard/number layouts (e.g. azerty)",
 	"minor fixes and improvements"
   ],

--- a/data/english/client.txt
+++ b/data/english/client.txt
@@ -220,6 +220,7 @@
 		items_ele_dmg			=	"Elemental Damage:"
 		items_chaos_dmg			=	"Chaos Damage:"
 		items_maptier			=	"Map Tier:"
+		items_mapreward			=	"Reward:"						;## T17 valdo maps have specific rewards
 		items_mapquantity		=	"Item Quantity:"
 		items_maprarity			=	"Item Rarity:"
 		items_mappacksize		=	"Monster Pack Size:"

--- a/data/versions.json
+++ b/data/versions.json
@@ -1,3 +1,4 @@
 {
-  "_release": [15407, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"]
+  "_release": [15407, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"],
+  "hotfix": 1
 }

--- a/modules/map-info.ahk
+++ b/modules/map-info.ahk
@@ -227,7 +227,7 @@ MapinfoGUI(mode := 1)
 		}
 	}
 
-	rolls := ["mods", "quantity", "pack size", "rarity", "maps", "scarabs", "currency"]
+	rolls := ["mods", "quantity", "rarity", "pack size", "maps", "scarabs", "currency"]
 	If (map.mods + map.quantity > 0)
 	{
 		;Gui, %GUI_name%: Add, Text, % "xs BackgroundTrans x1 y" yControl + hControl " Section HWNDhwnd Center w" width + settings.mapinfo.fHeight*2 - 3, % summary
@@ -386,6 +386,9 @@ MapinfoParse(mode := 1)
 		error := [LangTrans("m_general_language", 3) ":`n" LLK_StringCase(LangTrans("items_normal") " && " LangTrans("items_unique")), 1.5, "Red"]
 	Else If item.unid
 		error := [LangTrans("m_general_language", 3) ":`n" LLK_StringCase(LangTrans("items_unidentified")), 1.5, "Red"]
+	Else If InStr(clip, LangTrans("items_mapreward"))
+		error := [LangTrans("m_general_language", 3) ":`nvaldo maps", 1.5, "Red"]
+
 	If error
 	{
 		LLK_ToolTip(error.1, error.2,,,, error.3), LLK_Overlay(vars.hwnd.mapinfo.main, "destroy"), vars.mapinfo.active_map.cancel := 1


### PR DESCRIPTION
- map-info: highlighting thresholds for rarity and pack-size were swapped around
- map-info: T17 Valdo maps can no longer be loaded into the panel