### PR TITLE
v1.54.7 (Hotfix 2) merge

### DIFF
--- a/data/changelog.json
+++ b/data/changelog.json
@@ -1,6 +1,7 @@
 [
   [
 	["1.54.7", 15407],
+	"hotfix 2: omni-key compatibility fix, item-info base-percentile fix for new hybrid gloves",
 	"hotfix 1: highlighting thresholds for rarity and pack-size were swapped around (map-info)",
 	"added support for non-standard keyboard/number layouts (e.g. azerty)",
 	"minor fixes and improvements"

--- a/data/versions.json
+++ b/data/versions.json
@@ -1,4 +1,4 @@
 {
   "_release": [15407, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"],
-  "hotfix": 1
+  "hotfix": 2
 }

--- a/modules/hotkeys.ahk
+++ b/modules/hotkeys.ahk
@@ -81,6 +81,13 @@ HotkeysESC()
 		Gui, alarm_set: Destroy
 		vars.hwnd.alarm.alarm_set := ""
 	}
+	Else If WinExist("ahk_id " vars.hwnd.sanctum_debug)
+		Gui, sanctum_debug: Destroy
+	Else If WinExist("ahk_id " vars.hwnd.sanctum.main)
+	{
+		If !vars.sanctum.scanning
+			Sanctum_("close")
+	}
 	Else If WinExist("ahk_id " vars.hwnd.stash_index.main)
 		Stash_PriceIndex("destroy")
 	Else If WinExist("ahk_id " vars.hwnd.stash.main)
@@ -209,6 +216,15 @@ HotkeysTab()
 		Return
 	}
 
+	While settings.features.sanctum && InStr(vars.log.areaID, "sanctum") && !InStr(vars.log.areaID, "fellshrine") && GetKeyState(vars.hotkeys.tab, "P")
+		If (A_TickCount >= start + 200)
+		{
+			active .= " sanctum", vars.sanctum.lock := 0
+			If !WinExist("ahk_id " vars.hwnd.sanctum.main)
+				Sanctum_()
+			Break
+		}
+
 	While settings.general.hide_toolbar && GetKeyState(vars.hotkeys.tab, "P")
 		If (A_TickCount >= start + 200)
 		{
@@ -278,6 +294,8 @@ HotkeysTab()
 	}
 	Else KeyWait, % vars.hotkeys.tab
 
+	If InStr(active, "sanctum") && !vars.sanctum.lock && !vars.sanctum.scanning
+		Sanctum_("close")
 	If InStr(active, "LLK-panel") && settings.general.hide_toolbar
 		LLK_Overlay(vars.hwnd.LLK_panel.main, "hide")
 	If InStr(active, "alarm")
@@ -319,6 +337,13 @@ HotkeysTab()
 
 #If WinActive("ahk_group poe_ahk_window") && InStr(vars.stash.hover, "tab_")
 *~LButton::Stash_(StrReplace(vars.stash.hover, "tab_"))
+
+#If vars.sanctum.active && !vars.sanctum.lock && WinExist("ahk_id " vars.hwnd.sanctum.main)
+*Space::Sanctum_("lock")
+
+#If vars.sanctum.active && WinExist("ahk_id " vars.hwnd.sanctum.main) && (vars.general.wMouse = vars.hwnd.sanctum.main) && vars.general.cMouse && (check := LLK_HasVal(vars.hwnd.sanctum, vars.general.cMouse))
+*LButton::Sanctum_Mark(SubStr(check, InStr(check, "_") + 1), 1)
+*RButton::Sanctum_Mark(SubStr(check, InStr(check, "_") + 1), 2)
 
 #If vars.hwnd.stash_picker.main && vars.general.cMouse && WinExist("ahk_id " vars.hwnd.stash_picker.main) && LLK_PatternMatch(LLK_HasVal(vars.hwnd.stash_picker, vars.general.cMouse), "", ["confirm_", "bulk"])
 WheelUp::Stash_PricePicker("+")
@@ -472,7 +497,7 @@ Return
 ~+LButton UP::IteminfoTrigger(1)
 +RButton::IteminfoMarker()
 
-#If vars.pixelsearch.inventory.check && (settings.iteminfo.trigger || settings.mapinfo.trigger) && !vars.general.shift_trigger && (vars.general.wMouse = vars.hwnd.poe_client) ;shift-right-clicking currency to shift-click items after
+#If (vars.pixelsearch.inventory.check || !settings.features.pixelchecks) && (settings.iteminfo.trigger || settings.mapinfo.trigger) && !vars.general.shift_trigger && (vars.general.wMouse = vars.hwnd.poe_client) ;shift-right-clicking currency to shift-click items after
 
 ~+RButton UP::IteminfoTrigger()
 

--- a/modules/hotkeys.ahk
+++ b/modules/hotkeys.ahk
@@ -81,13 +81,6 @@ HotkeysESC()
 		Gui, alarm_set: Destroy
 		vars.hwnd.alarm.alarm_set := ""
 	}
-	Else If WinExist("ahk_id " vars.hwnd.sanctum_debug)
-		Gui, sanctum_debug: Destroy
-	Else If WinExist("ahk_id " vars.hwnd.sanctum.main)
-	{
-		If !vars.sanctum.scanning
-			Sanctum_("close")
-	}
 	Else If WinExist("ahk_id " vars.hwnd.stash_index.main)
 		Stash_PriceIndex("destroy")
 	Else If WinExist("ahk_id " vars.hwnd.stash.main)
@@ -216,15 +209,6 @@ HotkeysTab()
 		Return
 	}
 
-	While settings.features.sanctum && InStr(vars.log.areaID, "sanctum") && !InStr(vars.log.areaID, "fellshrine") && GetKeyState(vars.hotkeys.tab, "P")
-		If (A_TickCount >= start + 200)
-		{
-			active .= " sanctum", vars.sanctum.lock := 0
-			If !WinExist("ahk_id " vars.hwnd.sanctum.main)
-				Sanctum_()
-			Break
-		}
-
 	While settings.general.hide_toolbar && GetKeyState(vars.hotkeys.tab, "P")
 		If (A_TickCount >= start + 200)
 		{
@@ -294,8 +278,6 @@ HotkeysTab()
 	}
 	Else KeyWait, % vars.hotkeys.tab
 
-	If InStr(active, "sanctum") && !vars.sanctum.lock && !vars.sanctum.scanning
-		Sanctum_("close")
 	If InStr(active, "LLK-panel") && settings.general.hide_toolbar
 		LLK_Overlay(vars.hwnd.LLK_panel.main, "hide")
 	If InStr(active, "alarm")
@@ -337,13 +319,6 @@ HotkeysTab()
 
 #If WinActive("ahk_group poe_ahk_window") && InStr(vars.stash.hover, "tab_")
 *~LButton::Stash_(StrReplace(vars.stash.hover, "tab_"))
-
-#If vars.sanctum.active && !vars.sanctum.lock && WinExist("ahk_id " vars.hwnd.sanctum.main)
-*Space::Sanctum_("lock")
-
-#If vars.sanctum.active && WinExist("ahk_id " vars.hwnd.sanctum.main) && (vars.general.wMouse = vars.hwnd.sanctum.main) && vars.general.cMouse && (check := LLK_HasVal(vars.hwnd.sanctum, vars.general.cMouse))
-*LButton::Sanctum_Mark(SubStr(check, InStr(check, "_") + 1), 1)
-*RButton::Sanctum_Mark(SubStr(check, InStr(check, "_") + 1), 2)
 
 #If vars.hwnd.stash_picker.main && vars.general.cMouse && WinExist("ahk_id " vars.hwnd.stash_picker.main) && LLK_PatternMatch(LLK_HasVal(vars.hwnd.stash_picker, vars.general.cMouse), "", ["confirm_", "bulk"])
 WheelUp::Stash_PricePicker("+")

--- a/modules/item-checker.ahk
+++ b/modules/item-checker.ahk
@@ -20,7 +20,7 @@
 	settings.iteminfo.ilvl := (settings.general.lang_client != "english") ? 0 : !Blank(check := ini.settings["enable item-levels"]) ? check : 0
 	settings.iteminfo.itembase := !Blank(check := ini.settings["enable base-info"]) ? check : 1
 	settings.iteminfo.override := !Blank(check := ini.settings["enable blacklist-override"]) ? check : 0
-	settings.iteminfo.compare := (settings.general.lang_client != "english") ? 0 : !Blank(check := ini.settings["enable gear-tracking"]) ? check : 0
+	settings.iteminfo.compare := (settings.general.lang_client != "english") || !settings.features.pixelchecks ? 0 : !Blank(check := ini.settings["enable gear-tracking"]) ? check : 0
 
 	settings.iteminfo.rules := {}
 	settings.iteminfo.rules.res_weapons := (settings.general.lang_client != "english") ? 0 : !Blank(check := ini.settings["weapon res override"]) ? check : 0
@@ -418,7 +418,9 @@ Iteminfo2_stats()
 				item_combined_rel := item.stats.combined.relative := Format("{:0.0f}", item_combined/class_best_combined*100) ;how close is the combined keyue to the combined best-in-class?
 			}
 		}
-		item.base_percent := Format("{:0.0f}", (stat_value - base_min_%natural_defense_stat%)/(base_best_%natural_defense_stat% - base_min_%natural_defense_stat%)*100) ;base-percentile as calculated on trade
+		If (base_min_%natural_defense_stat% = base_best_%natural_defense_stat%)
+			item.base_percent := 100
+		Else item.base_percent := Format("{:0.0f}", (stat_value - base_min_%natural_defense_stat%)/(base_best_%natural_defense_stat% - base_min_%natural_defense_stat%)*100) ;base-percentile as calculated on trade
 	}
 
 	If (item.quality >= 25)
@@ -721,7 +723,7 @@ Iteminfo4_GUI()
 				Continue
 			}
 			dps_added += 1, style := (dps_added = 1) ? "xs Section" : "ys"
-			text := (item.dps.chaos = A_LoopField) ? Format("{:0.1f}", item.dps.chaos) : (item.dps.ele = A_LoopField) ? Format("{:0.1f}", item.dps.ele) : Format("{:0.1f}", item.dps.phys) ;text for the cell
+			text := (item.dps.chaos = A_LoopField) ? Format("{:0.1f}", item.dps.chaos) : (item.dps.ele = A_LoopField) ? Format((item.dps.ele < 1000) ? "{:0.1f}" : "{:0.0f}", item.dps.ele) : Format("{:0.1f}", item.dps.phys) ;text for the cell
 			label := (item.dps.chaos = A_LoopField) ? "chaos" : (item.dps.ele = A_LoopField) ? "allres" : "phys" ;icon for the cell
 			If !filler
 			{
@@ -2345,7 +2347,7 @@ IteminfoOverlays() ;show update buttons for specific gear-slots underneath the c
 	local
 	global vars, settings
 
-	If settings.iteminfo.compare
+	If settings.iteminfo.compare && settings.features.pixelchecks
 		For slot, val in vars.iteminfo.compare.slots
 		{
 			If vars.pixelsearch.inventory.check && LLK_IsBetween(vars.general.xMouse, val.x1, val.x2) && LLK_IsBetween(vars.general.yMouse, val.y1, val.y2) && (vars.log.areaID != "login")

--- a/modules/omni-key.ahk
+++ b/modules/omni-key.ahk
@@ -21,8 +21,14 @@
 		WinWaitActive, % "ahk_id " vars.hwnd.poe_client
 	}
 
+	If !settings.features.pixelchecks
+		Screenchecks_PixelSearch("inventory")
+
 	If vars.pixelsearch.inventory.check
 	{
+		If !settings.features.pixelchecks
+			vars.pixelsearch.inventory.check := 0
+
 		If WinExist("ahk_id " vars.hwnd.maptrackernotes_edit.main)
 		{
 			MaptrackerNoteAdd(), OmniRelease()

--- a/modules/settings menu.ahk
+++ b/modules/settings menu.ahk
@@ -340,7 +340,7 @@ Settings_cloneframes()
 	GUI := "settings_menu" vars.settings.GUI_toggle, x_anchor := vars.settings.xSelection + vars.settings.wSelection + vars.settings.xMargin*2
 	Gui, %GUI%: Add, Link, % "Section x" x_anchor " y"vars.settings.ySelection, <a href="https://github.com/Lailloken/Lailloken-UI/wiki/Clone-frames">wiki page</a>
 
-	If (vars.pixelsearch.gamescreen.x1 && (vars.pixelsearch.gamescreen.x1 != "ERROR") || vars.log.file_location) && settings.features.pixelchecks
+	If vars.pixelsearch.gamescreen.x1 && (vars.pixelsearch.gamescreen.x1 != "ERROR") && settings.features.pixelchecks || vars.log.file_location
 	{
 		Gui, %GUI%: Font, underline bold
 		Gui, %GUI%: Add, Text, % "xs Section y+"vars.settings.spacing, % LangTrans("m_clone_toggle")
@@ -1195,8 +1195,11 @@ Settings_iteminfo()
 	Gui, %GUI%: Add, Checkbox, % "xs Section gSettings_iteminfo2 HWNDhwnd Checked"settings.iteminfo.trigger, % LangTrans("m_iteminfo_shift")
 	vars.hwnd.settings.trigger := hwnd, vars.hwnd.help_tooltips["settings_iteminfo shift-click"] := hwnd
 
-	Gui, %GUI%: Add, Checkbox, % "xs Section gSettings_iteminfo2 HWNDhwnd Checked"settings.iteminfo.compare (settings.general.lang_client != "english" ? " cGray" : ""), % LangTrans("m_iteminfo_league")
-	vars.hwnd.settings.compare := hwnd, vars.hwnd.help_tooltips["settings_" (settings.general.lang_client = "english" ? "iteminfo league-start" : "lang unavailable") ] := hwnd
+	If settings.features.pixelchecks
+	{
+		Gui, %GUI%: Add, Checkbox, % "xs Section gSettings_iteminfo2 HWNDhwnd Checked"settings.iteminfo.compare (settings.general.lang_client != "english" ? " cGray" : ""), % LangTrans("m_iteminfo_league")
+		vars.hwnd.settings.compare := hwnd, vars.hwnd.help_tooltips["settings_" (settings.general.lang_client = "english" ? "iteminfo league-start" : "lang unavailable") ] := hwnd
+	}
 
 	If !settings.iteminfo.compare
 	{


### PR DESCRIPTION
- omni-key: fixed an oversight that disabled item-related features when background pixel-checks were disabled due to compatibility issues that cause heavy stuttering

- item-info: new hybrid glove bases (str-dex, maybe more) for some reason don't have a range on their defense-roll, so the panel would always show 0% as the percentile